### PR TITLE
Fix crash on unexpected properties

### DIFF
--- a/lib/connector.js
+++ b/lib/connector.js
@@ -107,7 +107,7 @@ Connector.prototype.id = function (model, prop) {
   if (!p) {
     console.trace('Property not found: ' + model + '.' + prop);
   }
-  return p.id;
+  return p && p.id;
 };
 
 /**


### PR DESCRIPTION
There is currently a bug in the MySQL connector: https://github.com/strongloop/loopback-connector-mysql/issues/52

@bajtos suggested a patch about three months ago, so I figured I'd just bring it in. It still logs an error, but it's better than crashing.