### PR TITLE
Fix crash in `id(model, prop)`

### DIFF
--- a/lib/connector.js
+++ b/lib/connector.js
@@ -104,10 +104,7 @@ Connector.prototype.idNames = function (model) {
  */
 Connector.prototype.id = function (model, prop) {
   var p = this._models[model].properties[prop];
-  if (!p) {
-    console.trace('Property not found: ' + model + '.' + prop);
-  }
-  return p.id;
+  return p && p.id;
 };
 
 /**


### PR DESCRIPTION
Before this change, an attempt to save a model instance with a dynamic
property to a MySQL datasource crashed the application.

This commit fixes the implementation of `id(model, property)` to
correctly handle the case when the property is not described in the
model definition.

Connect strongloop/loopback-datasource-juggler#367

/to @raymondfeng please review