### PR TITLE
Apply connector specific naming convention to id columns

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -129,7 +129,7 @@ SqlConnector.prototype.idColumn = function (model) {
  * @returns {String} the escaped id column name
  */
 SqlConnector.prototype.idColumnEscaped = function (model) {
-  return this.escapeName(this.getDataSource(model).idColumnName(model));
+  return this.escapeName(this.idColumn(model));
 };
 
 /**


### PR DESCRIPTION
The ID column should have the dbName filter (overriden in store specific connectors) applied when escaped.

I would have referenced an issue, but the repo doesn't seem to have them enabled.
