### PR TITLE
Enable Inversion of Control in connector hooks

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -405,7 +405,7 @@ SQLConnector.prototype.execute = function(sql, params, options, callback) {
     options: options
   };
   this.notifyObserversAround('execute', context, function(context, done) {
-    self.executeSQL(sql, params, options, function(err, info) {
+    self.executeSQL(context.req.sql, context.req.params, context.options, function(err, info) {
       if (!err && info != null) {
         context.res = info;
       }


### PR DESCRIPTION
Allow 'before execute' hooks to modify the SQL query, parameters and options by modifying the context object.