### PR TITLE
Fixed typo

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -58,7 +58,7 @@ Transaction.prototype.rollback = function(cb) {
  * @param cb
  */
 Transaction.begin = function(connector, options, cb) {
-  if (typeof isolationLevel === 'function' && cb === undefined) {
+  if (typeof options === 'function' && cb === undefined) {
     cb = options;
     options = {};
   }


### PR DESCRIPTION
Fixed typo in function `Transaction.begin`.