### PR TITLE
Query model's relations with SQL

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1047,6 +1047,12 @@ SQLConnector.prototype.buildSelect = function(model, filter, options) {
   return this.parameterize(selectStmt);
 };
 
+/**
+ * Build the SQL INNER JOIN clauses
+ * @param {string} model Model name
+ * @param {object} where An object for the where conditions
+ * @returns {ParameterizedSQL} The SQL INNER JOIN clauses
+ */
 SQLConnector.prototype.buildJoins = function(model, where) {
   var modelDef = this.getModelDefinition(model);
   var relations = modelDef.model.relations;

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1073,33 +1073,51 @@ SQLConnector.prototype.buildJoins = function(model, where) {
   var relations = modelDef.model.relations;
   var stmt = new ParameterizedSQL('', []);
 
+  var buildOneToMany = function buildOneToMany(modelFrom, keyFrom, modelTo, keyTo, filter) {
+    var modelToEscaped = this.tableEscaped(modelTo);
+    var innerFilter = assign({}, filter);
+    var innerIdField = {};
+    innerIdField[keyTo] = true;
+    innerFilter.fields = assign({}, innerFilter.fields, innerIdField);
+
+    var condition = this.columnEscaped(modelFrom, keyFrom) + '=' +
+      this.columnEscaped(modelTo, keyTo);
+
+    var innerSelect = this.buildSelect(modelTo, innerFilter, {
+      skipParameterize: true
+    });
+
+    return new ParameterizedSQL('INNER JOIN (', [])
+      .merge(innerSelect)
+      .merge(') AS ' + modelToEscaped)
+      .merge('ON ' + condition);
+  }.bind(this);
+
   for (var key in where) {
     if (!(key in relations)) continue;
 
     var rel = relations[key];
     var keyFrom = rel.keyFrom;
     var modelTo = rel.modelTo.definition.name;
-    var modelToEscaped = this.tableEscaped(modelTo);
     var keyTo = rel.keyTo;
 
-    var innerWhere = assign({}, where[key]);
-    var innerIdField = {};
-    innerIdField[keyTo] = true;
-    innerWhere.fields = assign({}, innerWhere.fields, innerIdField);
+    var join;
+    if (!rel.modelThrough) {
+      // 1:n relation
+      join = buildOneToMany(model, keyFrom, modelTo, keyTo, where[key]);
+    } else {
+      // n:m relation
+      var modelThrough = rel.modelThrough.definition.name;
+      var keyThrough = rel.keyThrough;
+      var modelToKey = rel.modelTo.definition._ids[0].name;
+      var innerFilter = {fields: {}};
+      innerFilter.fields[keyThrough] = true;
 
-    var condition = this.columnEscaped(model, keyFrom) + '=' +
-      this.columnEscaped(modelTo, keyTo);
-
-    var innerSelect = this.buildSelect(modelTo, innerWhere, {
-      skipParameterize: true
-    });
-
-    stmt
-      .merge('INNER JOIN (')
-      .merge(innerSelect)
-      .merge(') AS ' + modelToEscaped)
-      .merge('ON ' + condition);
-
+      var joinInner = buildOneToMany(model, keyFrom, modelThrough, keyTo, innerFilter);
+      join = buildOneToMany(modelThrough, keyThrough, modelTo, modelToKey, where[key]);
+      join = joinInner.merge(join);
+    }
+    stmt.merge(join);
   }
 
   return stmt;

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -989,6 +989,8 @@ SQLConnector.prototype.buildColumnNames = function(model, filter) {
  * @returns {ParameterizedSQL} Statement object {sql: ..., params: [...]}
  */
 SQLConnector.prototype.buildSelect = function(model, filter, options) {
+  options = options || {};
+
   if (!filter.order) {
     var idNames = this.idNames(model);
     if (idNames && idNames.length) {
@@ -1037,6 +1039,11 @@ SQLConnector.prototype.buildSelect = function(model, filter, options) {
     }
 
   }
+
+  if (options.skipParameterize === true) {
+    return selectStmt;
+  }
+
   return this.parameterize(selectStmt);
 };
 
@@ -1062,7 +1069,9 @@ SQLConnector.prototype.buildJoins = function(model, where) {
     var condition = this.columnEscaped(model, keyFrom) + '=' +
       this.columnEscaped(modelTo, keyTo);
 
-    var innerSelect = this.buildSelect(modelTo, innerWhere);
+    var innerSelect = this.buildSelect(modelTo, innerWhere, {
+      skipParameterize: true
+    });
 
     stmt
       .merge('INNER JOIN (')

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1186,6 +1186,45 @@ SQLConnector.prototype.find = function(model, id, options, cb) {
 Connector.defineAliases(SQLConnector.prototype, 'find', ['findById']);
 
 /**
+ * Build a SQL SELECT statement to count rows
+ * @param {String} model Model name
+ * @param {Object} where Where object
+ * @param {Object} options Options object
+ * @returns {ParameterizedSQL} Statement object {sql: ..., params: [...]}
+ */
+SQLConnector.prototype.buildCount = function(model, where, options) {
+  var haveRelationFilters = false;
+  if (where) {
+    var relations = this.getModelDefinition(model).model.relations;
+    if (relations) {
+      for (var key in where) {
+        if (key in relations) {
+          haveRelationFilters = true;
+          break;
+        }
+      }
+    }
+  }
+
+  var count = 'count(*)';
+  if (haveRelationFilters) {
+    var idColumn = this.columnEscaped(model, this.idColumn(model));
+    count = 'count(DISTINCT ' + idColumn + ')';
+  }
+
+  var stmt = new ParameterizedSQL('SELECT ' + count +
+    ' as "cnt" FROM ' + this.tableEscaped(model));
+
+  if (haveRelationFilters) {
+    var joinsStmts = this.buildJoins(model, where);
+    stmt = stmt.merge(joinsStmts);
+  }
+
+  stmt = stmt.merge(this.buildWhere(model, where));
+  return this.parameterize(stmt);
+};
+
+/**
  * Count all model instances by the where filter
  *
  * @param {String} model The model name
@@ -1202,10 +1241,8 @@ SQLConnector.prototype.count = function(model, where, options, cb) {
     where = tmp;
   }
 
-  var stmt = new ParameterizedSQL('SELECT count(*) as "cnt" FROM ' +
-    this.tableEscaped(model));
-  stmt = stmt.merge(this.buildWhere(model, where));
-  stmt = this.parameterize(stmt);
+  var stmt = this.buildCount(model, where, options);
+
   this.execute(stmt.sql, stmt.params,
     function(err, res) {
       if (err) {

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -229,7 +229,7 @@ SQLConnector.prototype.tableEscaped = function(model) {
  * @returns {String} The escaped column name
  */
 SQLConnector.prototype.columnEscaped = function(model, property) {
-  return this.escapeName(this.column(model, property));
+  return this.tableEscaped(model) + '.' + this.escapeName(this.column(model, property));
 };
 
 /*!
@@ -737,11 +737,17 @@ SQLConnector.prototype._buildWhere = function(model, where) {
     return new ParameterizedSQL('');
   }
   var self = this;
-  var props = self.getModelDefinition(model).properties;
+  var modelDef = self.getModelDefinition(model);
+  var props = modelDef.properties;
+  var relations = modelDef.model.relations;
 
   var whereStmts = [];
   for (var key in where) {
     var stmt = new ParameterizedSQL('', []);
+    if (relations && key in relations) {
+      // relationships are handled on joins
+      continue;
+    }
     // Handle and/or operators
     if (key === 'and' || key === 'or') {
       var branches = [];
@@ -990,10 +996,29 @@ SQLConnector.prototype.buildSelect = function(model, filter, options) {
     }
   }
 
-  var selectStmt = new ParameterizedSQL('SELECT ' +
+  var haveRelationFilters = false;
+  if (filter.where) {
+    var relations = this.getModelDefinition(model).model.relations;
+    if (relations) {
+      for (var key in filter.where) {
+        if (key in relations) {
+          haveRelationFilters = true;
+          break;
+        }
+      }
+    }
+  }
+  var distinct = haveRelationFilters ? 'DISTINCT ' : '';
+
+  var selectStmt = new ParameterizedSQL('SELECT ' + distinct +
     this.buildColumnNames(model, filter) +
     ' FROM ' + this.tableEscaped(model)
   );
+
+  if (haveRelationFilters) {
+    var joinsStmts = this.buildJoins(model, filter.where);
+    selectStmt.merge(joinsStmts);
+  }
 
   if (filter) {
 
@@ -1013,6 +1038,41 @@ SQLConnector.prototype.buildSelect = function(model, filter, options) {
 
   }
   return this.parameterize(selectStmt);
+};
+
+SQLConnector.prototype.buildJoins = function(model, where) {
+  var modelDef = this.getModelDefinition(model);
+  var relations = modelDef.model.relations;
+  var stmt = new ParameterizedSQL('', []);
+
+  for (var key in where) {
+    if (!(key in relations)) continue;
+
+    var rel = relations[key];
+    var keyFrom = rel.keyFrom;
+    var modelTo = rel.modelTo.definition.name;
+    var modelToEscaped = this.tableEscaped(modelTo);
+    var keyTo = rel.keyTo;
+
+    var innerWhere = Object.assign({}, where[key]);
+    var innerIdField = {};
+    innerIdField[keyTo] = true;
+    innerWhere.fields = Object.assign({}, innerWhere.fields, innerIdField);
+
+    var condition = this.columnEscaped(model, keyFrom) + '=' +
+      this.columnEscaped(modelTo, keyTo);
+
+    var innerSelect = this.buildSelect(modelTo, innerWhere);
+
+    stmt
+      .merge('INNER JOIN (')
+      .merge(innerSelect)
+      .merge(') AS ' + modelToEscaped)
+      .merge('ON ' + condition);
+
+  }
+
+  return stmt;
 };
 
 /**

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -863,10 +863,24 @@ SQLConnector.prototype.buildOrderBy = function(model, order) {
   var clauses = [];
   for (var i = 0, n = order.length; i < n; i++) {
     var t = order[i].split(/[\s,]+/);
-    if (t.length === 1) {
-      clauses.push(self.columnEscaped(model, order[i]));
+    var colName;
+    if (t[0].indexOf('.') < 0) {
+      colName = self.columnEscaped(model, t[0]);
     } else {
-      clauses.push(self.columnEscaped(model, t[0]) + ' ' + t[1]);
+      // Column name is in the format: relationName.columnName
+      var colSplit = t[0].split('.');
+      // Find the name of the relation's model ...
+      var modelDef = this.getModelDefinition(model);
+      var relation = modelDef.model.relations[colSplit[0]];
+      var colModel = relation.modelTo.definition.name;
+      // ... and escape them
+      colName = self.columnEscaped(colModel, colSplit[1]);
+    }
+
+    if (t.length === 1) {
+      clauses.push(colName);
+    } else {
+      clauses.push(colName + ' ' + t[1]);
     }
   }
   return 'ORDER BY ' + clauses.join(',');

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -5,6 +5,7 @@ var Connector = require('./connector');
 var debug = require('debug')('loopback:connector:sql');
 var ParameterizedSQL = require('./parameterized-sql');
 var Transaction = require('./transaction');
+var assign = require('./utils').assign;
 
 module.exports = SQLConnector;
 
@@ -1067,10 +1068,10 @@ SQLConnector.prototype.buildJoins = function(model, where) {
     var modelToEscaped = this.tableEscaped(modelTo);
     var keyTo = rel.keyTo;
 
-    var innerWhere = Object.assign({}, where[key]);
+    var innerWhere = assign({}, where[key]);
     var innerIdField = {};
     innerIdField[keyTo] = true;
-    innerWhere.fields = Object.assign({}, innerWhere.fields, innerIdField);
+    innerWhere.fields = assign({}, innerWhere.fields, innerIdField);
 
     var condition = this.columnEscaped(model, keyFrom) + '=' +
       this.columnEscaped(modelTo, keyTo);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,18 @@
+var _hasOwnProp = Object.prototype.hasOwnProperty;
+
+/**
+ * Object.assign polyfill
+ */
+var assign = Object.assign || function(target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+    for (var key in source) {
+      if (_hasOwnProp.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+  return target;
+};
+
+exports.assign = assign;

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -102,7 +102,7 @@ describe('sql connector', function() {
 
   it('should find escaped column name', function() {
     var column = connector.columnEscaped('customer', 'vip');
-    expect(column).to.eql('`VIP`');
+    expect(column).to.eql('`CUSTOMER`.`VIP`');
   });
 
   it('should convert to escaped id column value', function() {
@@ -113,7 +113,7 @@ describe('sql connector', function() {
   it('builds where', function() {
     var where = connector.buildWhere('customer', {name: 'John'});
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE `NAME`=?',
+      sql: 'WHERE `CUSTOMER`.`NAME`=?',
       params: ['John']
     });
   });
@@ -121,7 +121,7 @@ describe('sql connector', function() {
   it('builds where with null', function() {
     var where = connector.buildWhere('customer', {name: null});
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE `NAME` IS NULL',
+      sql: 'WHERE `CUSTOMER`.`NAME` IS NULL',
       params: []
     });
   });
@@ -129,7 +129,7 @@ describe('sql connector', function() {
   it('builds where with inq', function() {
     var where = connector.buildWhere('customer', {name: {inq: ['John', 'Mary']}});
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE `NAME` IN (?,?)',
+      sql: 'WHERE `CUSTOMER`.`NAME` IN (?,?)',
       params: ['John', 'Mary']
     });
   });
@@ -138,7 +138,7 @@ describe('sql connector', function() {
     var where = connector.buildWhere('customer',
       {or: [{name: 'John'}, {name: 'Mary'}]});
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE (`NAME`=?) OR (`NAME`=?)',
+      sql: 'WHERE (`CUSTOMER`.`NAME`=?) OR (`CUSTOMER`.`NAME`=?)',
       params: ['John', 'Mary']
     });
   });
@@ -147,7 +147,7 @@ describe('sql connector', function() {
     var where = connector.buildWhere('customer',
       {and: [{name: 'John'}, {vip: true}]});
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE (`NAME`=?) AND (`VIP`=?)',
+      sql: 'WHERE (`CUSTOMER`.`NAME`=?) AND (`CUSTOMER`.`VIP`=?)',
       params: ['John', true]
     });
   });
@@ -159,7 +159,7 @@ describe('sql connector', function() {
       }
     });
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE `NAME` REGEXP ?',
+      sql: 'WHERE `CUSTOMER`.`NAME` REGEXP ?',
       params: ['^J']
     });
   });
@@ -171,7 +171,7 @@ describe('sql connector', function() {
       }
     });
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE `NAME` REGEXP ?',
+      sql: 'WHERE `CUSTOMER`.`NAME` REGEXP ?',
       params: ['^J/i']
     });
   });
@@ -183,7 +183,7 @@ describe('sql connector', function() {
       }
     });
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE `NAME` REGEXP ?',
+      sql: 'WHERE `CUSTOMER`.`NAME` REGEXP ?',
       params: [/^J/]
     });
   });
@@ -195,7 +195,7 @@ describe('sql connector', function() {
       }
     });
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE `NAME` REGEXP ?',
+      sql: 'WHERE `CUSTOMER`.`NAME` REGEXP ?',
       params: [/^J/i]
     });
   });
@@ -207,7 +207,7 @@ describe('sql connector', function() {
       }
     });
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE `NAME` REGEXP ?',
+      sql: 'WHERE `CUSTOMER`.`NAME` REGEXP ?',
       params: [/^J/]
     });
   });
@@ -219,7 +219,7 @@ describe('sql connector', function() {
       }
     });
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE `NAME` REGEXP ?',
+      sql: 'WHERE `CUSTOMER`.`NAME` REGEXP ?',
       params: [new RegExp(/^J/i)]
     });
   });
@@ -228,30 +228,31 @@ describe('sql connector', function() {
     var where = connector.buildWhere('customer',
       {and: [{name: 'John'}, {or: [{vip: true}, {address: null}]}]});
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE (`NAME`=?) AND ((`VIP`=?) OR (`ADDRESS` IS NULL))',
+      sql: 'WHERE (`CUSTOMER`.`NAME`=?) AND ((`CUSTOMER`.`VIP`=?) OR ' +
+        '(`CUSTOMER`.`ADDRESS` IS NULL))',
       params: ['John', true]
     });
   });
 
   it('builds order by with one field', function() {
     var orderBy = connector.buildOrderBy('customer', 'name');
-    expect(orderBy).to.eql('ORDER BY `NAME`');
+    expect(orderBy).to.eql('ORDER BY `CUSTOMER`.`NAME`');
   });
 
   it('builds order by with two fields', function() {
     var orderBy = connector.buildOrderBy('customer', ['name', 'vip']);
-    expect(orderBy).to.eql('ORDER BY `NAME`,`VIP`');
+    expect(orderBy).to.eql('ORDER BY `CUSTOMER`.`NAME`,`CUSTOMER`.`VIP`');
   });
 
   it('builds order by with two fields and dirs', function() {
     var orderBy = connector.buildOrderBy('customer', ['name ASC', 'vip DESC']);
-    expect(orderBy).to.eql('ORDER BY `NAME` ASC,`VIP` DESC');
+    expect(orderBy).to.eql('ORDER BY `CUSTOMER`.`NAME` ASC,`CUSTOMER`.`VIP` DESC');
   });
 
   it('builds fields for columns', function() {
     var fields = connector.buildFields('customer',
       {name: 'John', vip: true, unknown: 'Random'});
-    expect(fields.names).to.eql(['`NAME`', '`VIP`']);
+    expect(fields.names).to.eql(['`CUSTOMER`.`NAME`', '`CUSTOMER`.`VIP`']);
     expect(fields.columnValues[0].toJSON()).to.eql(
       {sql: '?', params: ['John']});
     expect(fields.columnValues[1].toJSON()).to.eql(
@@ -262,7 +263,7 @@ describe('sql connector', function() {
     var fields = connector.buildFieldsForUpdate('customer',
       {name: 'John', vip: true});
     expect(fields.toJSON()).to.eql({
-      sql: 'SET `VIP`=?',
+      sql: 'SET `CUSTOMER`.`VIP`=?',
       params: [true]
     });
   });
@@ -271,35 +272,36 @@ describe('sql connector', function() {
     var fields = connector.buildFieldsForUpdate('customer',
       {name: 'John', vip: true}, false);
     expect(fields.toJSON()).to.eql({
-      sql: 'SET `NAME`=?,`VIP`=?',
+      sql: 'SET `CUSTOMER`.`NAME`=?,`CUSTOMER`.`VIP`=?',
       params: ['John', true]
     });
   });
 
   it('builds column names for SELECT', function() {
     var cols = connector.buildColumnNames('customer');
-    expect(cols).to.eql('`NAME`,`VIP`,`ADDRESS`');
+    expect(cols).to.eql('`CUSTOMER`.`NAME`,`CUSTOMER`.`VIP`,' +
+      '`CUSTOMER`.`ADDRESS`,`CUSTOMER`.`FAVORITE_STORE`');
   });
 
   it('builds column names with true fields filter for SELECT', function() {
     var cols = connector.buildColumnNames('customer', {fields: {name: true}});
-    expect(cols).to.eql('`NAME`');
+    expect(cols).to.eql('`CUSTOMER`.`NAME`');
   });
 
   it('builds column names with false fields filter for SELECT', function() {
     var cols = connector.buildColumnNames('customer', {fields: {name: false}});
-    expect(cols).to.eql('`VIP`,`ADDRESS`');
+    expect(cols).to.eql('`CUSTOMER`.`VIP`,`CUSTOMER`.`ADDRESS`,`CUSTOMER`.`FAVORITE_STORE`');
   });
 
   it('builds column names with array fields filter for SELECT', function() {
     var cols = connector.buildColumnNames('customer', {fields: ['name']});
-    expect(cols).to.eql('`NAME`');
+    expect(cols).to.eql('`CUSTOMER`.`NAME`');
   });
 
   it('builds DELETE', function() {
     var sql = connector.buildDelete('customer', {name: 'John'});
     expect(sql.toJSON()).to.eql({
-      sql: 'DELETE FROM `CUSTOMER` WHERE `NAME`=$1',
+      sql: 'DELETE FROM `CUSTOMER` WHERE `CUSTOMER`.`NAME`=$1',
       params: ['John']
     });
   });
@@ -307,7 +309,7 @@ describe('sql connector', function() {
   it('builds UPDATE', function() {
     var sql = connector.buildUpdate('customer', {name: 'John'}, {vip: false});
     expect(sql.toJSON()).to.eql({
-      sql: 'UPDATE `CUSTOMER` SET `VIP`=$1 WHERE `NAME`=$2',
+      sql: 'UPDATE `CUSTOMER` SET `CUSTOMER`.`VIP`=$1 WHERE `CUSTOMER`.`NAME`=$2',
       params: [false, 'John']
     });
   });
@@ -316,8 +318,9 @@ describe('sql connector', function() {
     var sql = connector.buildSelect('customer',
       {order: 'name', limit: 5, where: {name: 'John'}});
     expect(sql.toJSON()).to.eql({
-      sql: 'SELECT `NAME`,`VIP`,`ADDRESS` FROM `CUSTOMER`' +
-      ' WHERE `NAME`=$1 ORDER BY `NAME` LIMIT 5',
+      sql: 'SELECT `CUSTOMER`.`NAME`,`CUSTOMER`.`VIP`,`CUSTOMER`.`ADDRESS`,' +
+        '`CUSTOMER`.`FAVORITE_STORE` FROM `CUSTOMER` WHERE `CUSTOMER`.`NAME`=$1 ' +
+        'ORDER BY `CUSTOMER`.`NAME` LIMIT 5',
       params: ['John']
     });
   });
@@ -325,7 +328,7 @@ describe('sql connector', function() {
   it('builds INSERT', function() {
     var sql = connector.buildInsert('customer', {name: 'John', vip: true});
     expect(sql.toJSON()).to.eql({
-      sql: 'INSERT INTO `CUSTOMER`(`NAME`,`VIP`) VALUES($1,$2)',
+      sql: 'INSERT INTO `CUSTOMER`(`CUSTOMER`.`NAME`,`CUSTOMER`.`VIP`) VALUES($1,$2)',
       params: ['John', true]
     });
   });

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -364,6 +364,29 @@ describe('sql connector', function() {
     });
   });
 
+  it('builds SELECT with INNER JOIN and order by relation columns', function () {
+    var sql = connector.buildSelect('order', {
+      where: {
+        customer: {
+          fields: {
+            'name': true,
+            'vip': true
+          }
+        }
+      },
+      order: ['customer.vip DESC', 'customer.name ASC']
+    });
+
+    expect(sql.toJSON()).to.eql({
+      sql: 'SELECT DISTINCT `ORDER`.`ID`,`ORDER`.`DATE`,`ORDER`.`CUSTOMER_NAME`,' +
+      '`ORDER`.`STORE_ID` FROM `ORDER` INNER JOIN ( SELECT `CUSTOMER`.`NAME`,' +
+      '`CUSTOMER`.`VIP` FROM `CUSTOMER` ORDER BY `CUSTOMER`.`NAME` ) AS `CUSTOMER`' +
+      ' ON `ORDER`.`CUSTOMER_NAME`=`CUSTOMER`.`NAME`  ORDER BY ' +
+      '`CUSTOMER`.`VIP` DESC,`CUSTOMER`.`NAME` ASC',
+      params: []
+    });
+  });
+
   it('builds SELECT with multiple INNER JOIN', function () {
     var sql = connector.buildSelect('customer', {
       where: {


### PR DESCRIPTION
### Update:

This pull-request started as a proof of concept and with a ongoing development, now I have done everything I wanted. The included features are:

- [x] Query 1:n relations (Example below)
- [x] Query n:n relations (Example in https://github.com/strongloop/loopback-connector/pull/31#issuecomment-158819653)
- [x] Allow ordering using a relation's property (Example in https://github.com/strongloop/loopback-connector/pull/31#issuecomment-156429761)
- [x] Supports `count` queries as well

Thanks to @EmileSpecs and @ianbelcher for helping me test this PR.

Below is the original comment, for reference.

---

This feature is a must have on my project, so I started to work on it. I know that currently it is missing a lot of things. But I think that we can discuss it here and use this as a starting point to the final version of the feature, since this is something new to Loopback and will need docs and so on.

I will start with an example. Let's imagine that a model `Customer` have many `Address` and I want to get all the customers that live on Brazil. I can create the SQL like this:

```javascript
var sql = connector.buildSelect('customer', {
  where: {
    address: {
      where: {country: 'Brazil'}
    }
  }
});
```

And `sql` will be:

```
ParameterizedSQL {
  sql: 'SELECT DISTINCT `CUSTOMER`.`ID`,`CUSTOMER`.`NAME` FROM `CUSTOMER` INNER JOIN ( SELECT `ADDRESS`.`CUSTOMERID` FROM `ADDRESS` WHERE `ADDRESS`.`COUNTRY`=? ORDER BY `ADDRESS`.`ID` ) AS `ADDRESS` ON `CUSTOMER`.`ID`=`ADDRESS`.`CUSTOMERID`  ORDER BY `CUSTOMER`.`ID`',
  params: [ 'Brazil' ] }
```

Formatted SQL:

```sql
SELECT DISTINCT `CUSTOMER`.`ID`, 
                `CUSTOMER`.`NAME` 
FROM   `CUSTOMER` 
       INNER JOIN (SELECT `ADDRESS`.`CUSTOMERID` 
                   FROM   `ADDRESS` 
                   WHERE  `ADDRESS`.`COUNTRY` = ? 
                   ORDER  BY `ADDRESS`.`ID`) AS `ADDRESS` 
               ON `CUSTOMER`.`ID` = `ADDRESS`.`CUSTOMERID` 
ORDER  BY `CUSTOMER`.`ID` 
```

---

So, my proposal is to enable users to use the name of relation as a key inside `filter.where` and the value will be a full filter for this inner select. This allows the use of `order` and `limit` as well (and in the future `groupBy`, in case it gets implemented).

The implementation is recursive, allowing to nest multiple filters.

It's worth pointing out that all the current failing tests are because I had to include the table name whenever column names were used, to fix ambiguity problems in some cases. As far as I could check, all the resulting SQLs were still valid.

