### PR TITLE
1. Error logging. 2. Options argument of model's include function to …

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1069,10 +1069,6 @@ SQLConnector.prototype.all = function find(model, filter, options, cb) {
       return self.fromRow(model, obj);
     });
     if (filter && filter.include) {
-      if(filter.where) {
-        options.filterWhere = filter.where;
-      }
-
       self.getModelDefinition(model).model.include(
         objs, filter.include, options, cb);
     } else {

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -406,6 +406,10 @@ SQLConnector.prototype.execute = function(sql, params, options, callback) {
   };
   this.notifyObserversAround('execute', context, function(context, done) {
     self.executeSQL(context.req.sql, context.req.params, context.options, function(err, info) {
+      if(err){
+        debug('Error: %j %j %j', err, context.req.sql, context.req.params);
+      }
+
       if (!err && info != null) {
         context.res = info;
       }
@@ -1065,6 +1069,10 @@ SQLConnector.prototype.all = function find(model, filter, options, cb) {
       return self.fromRow(model, obj);
     });
     if (filter && filter.include) {
+      if(filter.where) {
+        options.filterWhere = filter.where;
+      }
+
       self.getModelDefinition(model).model.include(
         objs, filter.include, options, cb);
     } else {


### PR DESCRIPTION
…pass filter.where object.

_1. Error logging

I would like to add logging of connector's errors to facilitate debugging of dynamic SQL execution.
I had to enable this logging while debugging an issue of loopback not being able to process a filter with relation that was caused by the second dynamic SQL statement of the two generated for this filter. This SQL statement contained 'where in (...)' clause with too many(~50K) items that SQL Server engine considers as too complex and refuses to execute. It looks like it has the limit of ~26K items to trigger this behavior.

I was able to fix the error by injecting OPTION(hash join) query hint in mssql connector's buildSelect function, so the query was executed successfully and the result was received by the loopback connector. However, I observed loopback processing the result indefinitely, while all CPU cores' utilization by node.exe process stayed at ~50%.

_2. Options argument of model's include function to contain a property initialized with filter.where object.

I would like to pass filter.where object to model's include function. The options argument populated with this object is intended to to be used by mssql connector to build PARTITION BY clause. The corresponding pull request in mssql connector repo will follow.