### PR TITLE
don't assume that the model exists

### DIFF
--- a/lib/connector.js
+++ b/lib/connector.js
@@ -106,8 +106,8 @@ Connector.prototype.getModelDefinition = function(modelName) {
  * @returns {Object} The connector specific settings
  */
 Connector.prototype.getConnectorSpecificSettings = function(modelName) {
-  var definition = this.getModelDefinition(modelName) || {};
-  var settings = definition.settings || {};
+  var definition = this.getModelDefinition(modelName);
+  var settings = definition && definitions.settings || {};
 
   return settings[this.name];
 };

--- a/lib/connector.js
+++ b/lib/connector.js
@@ -106,7 +106,9 @@ Connector.prototype.getModelDefinition = function(modelName) {
  * @returns {Object} The connector specific settings
  */
 Connector.prototype.getConnectorSpecificSettings = function(modelName) {
-  var settings = this.getModelDefinition(modelName).settings || {};
+  var definition = this.getModelDefinition(modelName) || {};
+  var settings = definition.settings || {};
+
   return settings[this.name];
 };
 

--- a/lib/connector.js
+++ b/lib/connector.js
@@ -108,7 +108,6 @@ Connector.prototype.getModelDefinition = function(modelName) {
 Connector.prototype.getConnectorSpecificSettings = function(modelName) {
   var definition = this.getModelDefinition(modelName);
   var settings = definition && definitions.settings || {};
-
   return settings[this.name];
 };
 


### PR DESCRIPTION
this is a pr to fix a bug reported in loopback-connector-postgresql (https://github.com/strongloop/loopback-connector-postgresql/issues/142)

the problem is that when doing database discovery, the models may not actually exist, so calling **this.getModelDefinition(modelName).settings** will fail if _models[modelName] is null

