### PR TITLE
Ensure that a model exists before using setttings

### DIFF
--- a/lib/connector.js
+++ b/lib/connector.js
@@ -106,7 +106,8 @@ Connector.prototype.getModelDefinition = function(modelName) {
  * @returns {Object} The connector specific settings
  */
 Connector.prototype.getConnectorSpecificSettings = function(modelName) {
-  var settings = this.getModelDefinition(modelName).settings || {};
+  var definition = this.getModelDefinition(modelName);
+  var settings = definition && definition.settings || {};
   return settings[this.name];
 };
 


### PR DESCRIPTION
When performing database discovery, a model may not yet exist in loopback.
This patch fixes a bug where it is assumed that the model exists by
getting the model first, then checking if it is valid before accessing
the settings property
