### PR TITLE
Fix for WHERE clause when a field is defined as object

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -857,7 +857,7 @@ SQLConnector.prototype._buildWhere = function(model, where) {
     /* eslint-enable one-var */
     if (expression === null || expression === undefined) {
       stmt.merge(columnName + ' IS NULL');
-    } else if (expression && expression.constructor === Object  && p.type !== Object) {
+    } else if (expression && expression.constructor === Object && p.type !== Object) {
       var operator = Object.keys(expression)[0];
       // Get the expression without the operator
       expression = expression[operator];

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -857,7 +857,7 @@ SQLConnector.prototype._buildWhere = function(model, where) {
     /* eslint-enable one-var */
     if (expression === null || expression === undefined) {
       stmt.merge(columnName + ' IS NULL');
-    } else if (expression && expression.constructor === Object) {
+    } else if (expression && expression.constructor === Object  && p.type !== Object) {
       var operator = Object.keys(expression)[0];
       // Get the expression without the operator
       expression = expression[operator];

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -23,7 +23,6 @@ describe('sql connector', function() {
     connector = ds.connector;
     connector._tables = {};
     connector._models = {};
-    /* eslint camelcase: 0 */
     Customer = ds.createModel('customer',
       {
         name: {
@@ -41,7 +40,7 @@ describe('sql connector', function() {
           },
         },
         address: String,
-        object_field: Object,
+        objectField: Object,
       },
       { testdb: { table: 'CUSTOMER' }});
   });
@@ -130,7 +129,7 @@ describe('sql connector', function() {
 
   it('builds where with and', function() {
     var where = connector.buildWhere('customer',
-        { and: [{ name: 'John' }, { vip: true }] });
+      { and: [{ name: 'John' }, { vip: true }] });
     expect(where.toJSON()).to.eql({
       sql: 'WHERE (`NAME`=?) AND (`VIP`=?)',
       params: ['John', true],
@@ -140,9 +139,9 @@ describe('sql connector', function() {
   it('builds where with object field', function() {
     var objectValue = { some: 'value', something: 1 };
     var where = connector.buildWhere('customer',
-        { object_field: objectValue  });
+        { objectField: objectValue  });
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE `OBJECT_FIELD`=?',
+      sql: 'WHERE `OBJECTFIELD`=?',
       params: [objectValue],
     });
   });
@@ -273,7 +272,7 @@ describe('sql connector', function() {
 
   it('builds column names for SELECT', function() {
     var cols = connector.buildColumnNames('customer');
-    expect(cols).to.eql('`NAME`,`VIP`,`ADDRESS`,`OBJECT_FIELD`');
+    expect(cols).to.eql('`NAME`,`VIP`,`ADDRESS`,`OBJECTFIELD`');
   });
 
   it('builds column names with true fields filter for SELECT', function() {
@@ -283,7 +282,7 @@ describe('sql connector', function() {
 
   it('builds column names with false fields filter for SELECT', function() {
     var cols = connector.buildColumnNames('customer', { fields: { name: false }});
-    expect(cols).to.eql('`VIP`,`ADDRESS`,`OBJECT_FIELD`');
+    expect(cols).to.eql('`VIP`,`ADDRESS`,`OBJECTFIELD`');
   });
 
   it('builds column names with array fields filter for SELECT', function() {
@@ -311,7 +310,7 @@ describe('sql connector', function() {
     var sql = connector.buildSelect('customer',
       { order: 'name', limit: 5, where: { name: 'John' }});
     expect(sql.toJSON()).to.eql({
-      sql: 'SELECT `NAME`,`VIP`,`ADDRESS`,`OBJECT_FIELD` FROM `CUSTOMER`' +
+      sql: 'SELECT `NAME`,`VIP`,`ADDRESS`,`OBJECTFIELD` FROM `CUSTOMER`' +
       ' WHERE `NAME`=$1 ORDER BY `NAME` LIMIT 5',
       params: ['John'],
     });

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -23,6 +23,7 @@ describe('sql connector', function() {
     connector = ds.connector;
     connector._tables = {};
     connector._models = {};
+    /* eslint camelcase: 0 */
     Customer = ds.createModel('customer',
       {
         name: {
@@ -40,6 +41,7 @@ describe('sql connector', function() {
           },
         },
         address: String,
+        object_field: Object,
       },
       { testdb: { table: 'CUSTOMER' }});
   });
@@ -128,10 +130,20 @@ describe('sql connector', function() {
 
   it('builds where with and', function() {
     var where = connector.buildWhere('customer',
-      { and: [{ name: 'John' }, { vip: true }] });
+        { and: [{ name: 'John' }, { vip: true }] });
     expect(where.toJSON()).to.eql({
       sql: 'WHERE (`NAME`=?) AND (`VIP`=?)',
       params: ['John', true],
+    });
+  });
+
+  it('builds where with object field', function() {
+    var objectValue = { some: 'value', something: 1 };
+    var where = connector.buildWhere('customer',
+        { object_field: objectValue  });
+    expect(where.toJSON()).to.eql({
+      sql: 'WHERE `OBJECT_FIELD`=?',
+      params: [objectValue],
     });
   });
 
@@ -261,7 +273,7 @@ describe('sql connector', function() {
 
   it('builds column names for SELECT', function() {
     var cols = connector.buildColumnNames('customer');
-    expect(cols).to.eql('`NAME`,`VIP`,`ADDRESS`');
+    expect(cols).to.eql('`NAME`,`VIP`,`ADDRESS`,`OBJECT_FIELD`');
   });
 
   it('builds column names with true fields filter for SELECT', function() {
@@ -271,7 +283,7 @@ describe('sql connector', function() {
 
   it('builds column names with false fields filter for SELECT', function() {
     var cols = connector.buildColumnNames('customer', { fields: { name: false }});
-    expect(cols).to.eql('`VIP`,`ADDRESS`');
+    expect(cols).to.eql('`VIP`,`ADDRESS`,`OBJECT_FIELD`');
   });
 
   it('builds column names with array fields filter for SELECT', function() {
@@ -299,7 +311,7 @@ describe('sql connector', function() {
     var sql = connector.buildSelect('customer',
       { order: 'name', limit: 5, where: { name: 'John' }});
     expect(sql.toJSON()).to.eql({
-      sql: 'SELECT `NAME`,`VIP`,`ADDRESS` FROM `CUSTOMER`' +
+      sql: 'SELECT `NAME`,`VIP`,`ADDRESS`,`OBJECT_FIELD` FROM `CUSTOMER`' +
       ' WHERE `NAME`=$1 ORDER BY `NAME` LIMIT 5',
       params: ['John'],
     });


### PR DESCRIPTION
The LoopBack replication mechanism does a find with the whole current object in the where clause. If one of the fields is defined as 'object', the SELECT gets an invalid SQL in the loopback-mysql-connector. 
I traced this down to a bug in loopback-connector, for which this pull request provides a test as well as the fix.
