### PR TITLE
[WIP] SQL extended operators

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -642,6 +642,7 @@ SQLConnector.prototype.buildUpdate = function(model, where, data, options) {
   };
   var usedOperators = false;
 
+  // Detect use of extended operators
   if (allowExtendedOperators) {
 
     var acceptedOperators = ['$inc'];
@@ -655,21 +656,43 @@ SQLConnector.prototype.buildUpdate = function(model, where, data, options) {
     }
   }
 
+  // Apply extented operators
   if(usedOperators) {
+    var operatorsFound = Object.keys(parsedData);
     var props = this.getModelDefinition(model).properties;
 
-    //TODO: For each property in $inc
-    var prop = this.columnEscaped(model, parsedData.$inc.name);
-    fields.names.push(prop);
-    var inc = this.toColumnValue(props.stars, parsedData.$inc.amount);
-    var field = new ParameterizedSQL(''.concat(prop, '+' , PLACEHOLDER), [inc])// Cannot put prop with placeholder for same reason than above
-    fields.columnValues.push(field);
+    for(var i = 0 ; i < operatorsFound.length ; i++) {
+      var op = operatorsFound[i];
+      var field = this.buildFieldForExtendedOperator(model, parsedData[op], op);
+      var prop = this.columnEscaped(model, parsedData[op].name || '');
+      fields.names.push(prop);
+      fields.columnValues.push(field);
+    }
     fields = this._constructUpdateParameterizedSQL(fields);
-
   } else {
      fields = this.buildFieldsForUpdate(model, data);
   }
   return this._constructUpdateQuery(model, where, fields);
+};
+
+SQLConnector.prototype.buildFieldForExtendedOperator = function(model, data, operator) {
+  var props = this.getModelDefinition(model).properties;
+  var field = new ParameterizedSQL();
+
+  data.name = data.name || '';
+  var prop = this.columnEscaped(model, data.name);
+
+  switch(operator) {
+    case '$inc':
+      data.amount = data.amount || 0;
+      var inc = this.toColumnValue(props[data.name], data.amount);
+      field = new ParameterizedSQL(''.concat(prop, '+' , PLACEHOLDER), [inc]);
+      break;
+    default:
+      debug("Operator %s not recognized.", operator);
+      break;
+  }
+  return field;
 };
 
 /**

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -664,8 +664,8 @@ SQLConnector.prototype.buildUpdate = function(model, where, data, options) {
       var op = operatorsFound[i];
       var field = this.buildFieldForExtendedOperator(model, parsedData[op], op);
 
-      if(field) {
-        var prop = this.columnEscaped(model, parsedData[op].name || '');
+      if(field && typeof parsedData[op].name !== 'undefined') {
+        var prop = this.columnEscaped(model, parsedData[op].name);
         fields.names.push(prop);
         fields.columnValues.push(field);
       }

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -635,7 +635,11 @@ SQLConnector.prototype._buildWhereObjById = function(model, id, data) {
 SQLConnector.prototype.buildUpdate = function(model, where, data, options) {
   // Remi
   var allowExtendedOperators = true; // Use model settings
-  var fields = {};
+  var fields = {
+    names: [],
+    columnValues: [],
+    properties: []
+  };
   var usedOperators = false;
 
   if (allowExtendedOperators) {
@@ -646,14 +650,22 @@ SQLConnector.prototype.buildUpdate = function(model, where, data, options) {
     for(var i = 0 ; i < acceptedOperators.length ; i++) {
       if(data[acceptedOperators[i]]) {
         parsedData[acceptedOperators[i]] = data[acceptedOperators[i]];
-        console.log("acceptedOperators :" + acceptedOperators[i]);
         usedOperators = true;
       }
     }
   }
 
   if(usedOperators) {
-    fields = {};
+    var props = this.getModelDefinition(model).properties;
+
+    //TODO: For each property in $inc
+    var prop = this.columnEscaped(model, parsedData.$inc.name);
+    fields.names.push(prop);
+    var inc = this.toColumnValue(props.stars, parsedData.$inc.amount);
+    var field = new ParameterizedSQL(''.concat(prop, '+' , PLACEHOLDER), [inc])// Cannot put prop with placeholder for same reason than above
+    fields.columnValues.push(field);
+    fields = this._constructUpdateParameterizedSQL(fields);
+
   } else {
      fields = this.buildFieldsForUpdate(model, data);
   }

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -633,7 +633,6 @@ SQLConnector.prototype._buildWhereObjById = function(model, id, data) {
  * @returns {ParameterizedSQL} The UPDATE SQL statement
  */
 SQLConnector.prototype.buildUpdate = function(model, where, data, options) {
-  // Remi
   var allowExtendedOperators = true; // Use model settings
   var fields = {
     names: [],
@@ -645,7 +644,7 @@ SQLConnector.prototype.buildUpdate = function(model, where, data, options) {
   // Detect use of extended operators
   if (allowExtendedOperators) {
 
-    var acceptedOperators = ['$inc'];
+    var acceptedOperators = ['$inc', '$mul'];
     var parsedData = {};
 
     for(var i = 0 ; i < acceptedOperators.length ; i++) {
@@ -664,9 +663,12 @@ SQLConnector.prototype.buildUpdate = function(model, where, data, options) {
     for(var i = 0 ; i < operatorsFound.length ; i++) {
       var op = operatorsFound[i];
       var field = this.buildFieldForExtendedOperator(model, parsedData[op], op);
-      var prop = this.columnEscaped(model, parsedData[op].name || '');
-      fields.names.push(prop);
-      fields.columnValues.push(field);
+
+      if(field) {
+        var prop = this.columnEscaped(model, parsedData[op].name || '');
+        fields.names.push(prop);
+        fields.columnValues.push(field);
+      }
     }
     fields = this._constructUpdateParameterizedSQL(fields);
   } else {
@@ -677,16 +679,21 @@ SQLConnector.prototype.buildUpdate = function(model, where, data, options) {
 
 SQLConnector.prototype.buildFieldForExtendedOperator = function(model, data, operator) {
   var props = this.getModelDefinition(model).properties;
-  var field = new ParameterizedSQL();
+  var field = undefined;
 
   data.name = data.name || '';
   var prop = this.columnEscaped(model, data.name);
 
   switch(operator) {
     case '$inc':
-      data.amount = data.amount || 0;
+      data.amount = (typeof data.amount === 'undefined') ? 0 : data.amount;
       var inc = this.toColumnValue(props[data.name], data.amount);
       field = new ParameterizedSQL(''.concat(prop, '+' , PLACEHOLDER), [inc]);
+      break;
+    case '$mul':
+      data.amount = (typeof data.amount === 'undefined') ? 1 : data.amount;
+      var mul = this.toColumnValue(props[data.name], data.amount);
+      field = new ParameterizedSQL(''.concat(prop, '*' , PLACEHOLDER), [mul]);
       break;
     default:
       debug("Operator %s not recognized.", operator);

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -633,7 +633,30 @@ SQLConnector.prototype._buildWhereObjById = function(model, id, data) {
  * @returns {ParameterizedSQL} The UPDATE SQL statement
  */
 SQLConnector.prototype.buildUpdate = function(model, where, data, options) {
-  var fields = this.buildFieldsForUpdate(model, data);
+  // Remi
+  var allowExtendedOperators = true; // Use model settings
+  var fields = {};
+  var usedOperators = false;
+
+  if (allowExtendedOperators) {
+
+    var acceptedOperators = ['$inc'];
+    var parsedData = {};
+
+    for(var i = 0 ; i < acceptedOperators.length ; i++) {
+      if(data[acceptedOperators[i]]) {
+        parsedData[acceptedOperators[i]] = data[acceptedOperators[i]];
+        console.log("acceptedOperators :" + acceptedOperators[i]);
+        usedOperators = true;
+      }
+    }
+  }
+
+  if(usedOperators) {
+    fields = {};
+  } else {
+     fields = this.buildFieldsForUpdate(model, data);
+  }
   return this._constructUpdateQuery(model, where, fields);
 };
 

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -677,6 +677,13 @@ SQLConnector.prototype.buildUpdate = function(model, where, data, options) {
   return this._constructUpdateQuery(model, where, fields);
 };
 
+/**
+ * Build a field for any of the extended operators
+ * @param {String} model The model name
+ * @param {Object} data The data to be changed
+ * @param {Object} operator The extended operator to use for this field
+ * @returns {ParameterizedSQL} The SQL statement
+ */
 SQLConnector.prototype.buildFieldForExtendedOperator = function(model, data, operator) {
   var props = this.getModelDefinition(model).properties;
   var field = undefined;


### PR DESCRIPTION
Draft implementation proposed for https://github.com/strongloop/loopback-connector-mysql/issues/206

`$inc` and `$mul` operators are working properly, when calling `Model.update`

Remains to be done:
- check if extended operators are allowed, either via global model config, or options passed to `SQLConnector.prototype.buildUpdate`.
- Push tests 
- More operators ?

@superkhau So far I have multiple tests implemented in a local clone of `loopback-connector-mysql`. If I move & push them to `loopback-datasource-juggler`, they will most likely break tests for non-sql databases that don't implement these operators yet. What do you think should be done ?
