### PR TITLE
sql: update attributes without count

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -589,7 +589,7 @@ Connector.defineAliases(SQLConnector.prototype, 'destroyAll', ['deleteAll']);
 SQLConnector.prototype.updateAttributes = function(model, id, data, options, cb) {
   if (!isIdValuePresent(id, cb)) return;
   var where = this._buildWhereObjById(model, id, data);
-  this.updateAll(model, where, data, options, cb);
+  this.updateAllNoCount(model, where, data, options, cb);
 };
 
 /**
@@ -680,6 +680,24 @@ SQLConnector.prototype.update = function(model, where, data, options, cb) {
 };
 
 /**
+ * Update all instances that match the where clause with the given data, but
+ * without returning the count.
+ * @param {String} model The model name
+ * @param {Object} where The where object
+ * @param {Object} data The property/value object representing changes
+ * to be made
+ * @param {Object} options The options object
+ * @param {Function} cb The callback function
+ */
+SQLConnector.prototype.updateNoCount = function(model, where, data,
+  options, cb) {
+  var stmt = this.buildUpdate(model, where, data, options);
+  this.execute(stmt.sql, stmt.params, options, function(err) {
+    cb(err);
+  });
+};
+
+/**
  * Replace all instances that match the where clause with the given data
  * @param {String} model The model name
  * @param {Object} where The where object
@@ -705,6 +723,8 @@ SQLConnector.prototype._executeAlteringQuery = function(model, sql, params, opti
 Connector.defineAliases(SQLConnector.prototype, 'update', ['updateAll']);
 Connector.defineAliases(SQLConnector.prototype, 'replace', ['replaceAll']);
 
+Connector.defineAliases(SQLConnector.prototype, 'updateNoCount',
+  ['updateAllNoCount']);
 /**
  * Build the SQL WHERE clause for the where object
  * @param {string} model Model name


### PR DESCRIPTION
updateAttributes will now use an updateAllNoCount alias that does
not return the count.

### Description
#### Related issues
https://github.com/strongloop/loopback-connector/issues/71

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
