### PR TITLE
Fix replaceById to report an error when id not found

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -690,8 +690,22 @@ SQLConnector.prototype.update = function(model, where, data, options, cb) {
  */
 SQLConnector.prototype._replace = function(model, where, data, options, cb) {
   var stmt = this.buildReplace(model, where, data, options);
-  this.execute(stmt.sql, stmt.params, options, cb);
+  this.execute(stmt.sql, stmt.params, options, function(err, info) {
+    if (err) return cb(err);
+    if (info.affectedRows === 0) {
+      return cb(errorIdNotFoundForReplace(where.id));
+    } else {
+      return cb(null, info);
+    }
+  });
 };
+
+function errorIdNotFoundForReplace(idValue) {
+  var msg = g.f('Could not replace. Object with id %s does not exist!', idValue);
+  var error = new Error(msg);
+  error.statusCode = error.status = 404;
+  return error;
+}
 
 SQLConnector.prototype._executeAlteringQuery = function(model, sql, params, options, cb) {
   var self = this;


### PR DESCRIPTION
connect to https://github.com/strongloop/loopback-datasource-juggler/issues/1171
connect to https://github.com/strongloop/loopback-connector-mysql/issues/230
connect to https://github.com/strongloop/loopback-connector-postgresql/issues/204
connect to https://github.com/strongloop/loopback-connector-mssql/issues/116
connect to https://github.com/strongloop/loopback-datasource-juggler/issues/1235

this pr is a prerequisite for:  https://github.com/strongloop/loopback-datasource-juggler/pull/1210

Unit test is included in:

'loopback-datasource-juggler/test/manipulation.test.js' section  'replaceOrCreate when forceId is true' which is being called from 'test/imported.test.js' from each sql connector. 

testedt with loopback-connectors:
- [x] MySQL
- [x] PostgresSQL
- [x] mssql
- [ ] dashdb