### PR TITLE
Fix replaceById for Oracle

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -689,10 +689,14 @@ SQLConnector.prototype.update = function(model, where, data, options, cb) {
  * @param {Function} cb The callback function
  */
 SQLConnector.prototype._replace = function(model, where, data, options, cb) {
+  var self = this;
   var stmt = this.buildReplace(model, where, data, options);
   this.execute(stmt.sql, stmt.params, options, function(err, info) {
     if (err) return cb(err);
-    if (info.affectedRows === 0) {
+    var affectedRows = self.getCountForAffectedRows(model, info);
+    var rowCount = typeof (affectedRows) === 'number' ?
+      affectedRows : info.affectedRows;
+    if (rowCount === 0) {
       return cb(errorIdNotFoundForReplace(where.id));
     } else {
       return cb(null, info);


### PR DESCRIPTION
### Description
Oracle uses `rowsAffected` instead of `affectedRows`, so that pr is to fix the test failure and fix the bug in question when we use replaceById when the id does not exist in db. 

#### Related issues
Unit tests in Juggler. 
