### PR TITLE
Respect user specified datatypes for databases

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -172,19 +172,34 @@ SQLConnector.prototype.addPropertyToActual = function(model, propName) {
 
 SQLConnector.prototype.columnDataType = function(model, property) {
   var columnMetadata = this.columnMetadata(model, property);
+  var prop = this.getModelDefinition(model).properties[property];
   var colType = columnMetadata && columnMetadata.dataType;
+  var colLength = columnMetadata && columnMetadata.dataLength ||
+        (prop && (prop.length || prop.limit));
+  var colPrecision = columnMetadata && columnMetadata.dataPrecision ||
+        (prop && prop.precision);
+
+  // If the user specified the backend data type in the configuration,
+  // output that
   if (colType) {
     colType = colType.toUpperCase();
+    if (colLength) {
+      colType += ' (' + colLength;
+      if (colPrecision) {
+        colType += ',' + colPrecision;
+      }
+      colType += ')';
+    }
+    return colType;
   }
-  var prop = this.getModelDefinition(model).properties[property];
+
+  // if the underlying datatype was not specified defer to the model
+  // object, which generally defers to the underlying connector
+
   if (!prop) {
     return null;
   }
-  var colLength = columnMetadata && columnMetadata.dataLength ||
-    prop.length || prop.limit;
-  if (colType && colLength) {
-    return colType + '(' + colLength + ')';
-  }
+
   return this.buildColumnType(prop);
 };
 

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -34,7 +34,22 @@ describe('sql connector', function() {
             dataType: 'VARCHAR',
             dataLength: 32,
           },
-        }, vip: {
+        }, preferences: {
+          id: true,
+          type: 'JSON',
+          testdb: {
+            dataType: 'jsonb',
+          },
+        }, balance: {
+          id: true,
+          type: Number,
+          testdb: {
+            dataType: 'decimal',
+            dataLength: 18,
+            dataPrecision: 2,
+          },
+        },
+        vip: {
           type: Boolean,
           testdb: {
             column: 'VIP',
@@ -62,6 +77,21 @@ describe('sql connector', function() {
       dataType: 'VARCHAR',
       dataLength: 32,
     });
+  });
+
+  it('should respect user specified data type', function() {
+    var dataType = connector.columnDataType('customer', 'preferences');
+    expect(dataType).to.eql('JSONB');
+  });
+
+  it('should respect user specified data types with length', function() {
+    var dataType = connector.columnDataType('customer', 'name');
+    expect(dataType).to.eql('VARCHAR (32)');
+  });
+
+  it('should respect user specified data types with length & precision', function() {
+    var dataType = connector.columnDataType('customer', 'balance');
+    expect(dataType).to.eql('DECIMAL (18,2)');
   });
 
   it('should map property name', function() {
@@ -262,7 +292,7 @@ describe('sql connector', function() {
 
   it('builds column names for SELECT', function() {
     var cols = connector.buildColumnNames('customer');
-    expect(cols).to.eql('`NAME`,`VIP`,`ADDRESS`');
+    expect(cols).to.eql('`NAME`,`PREFERENCES`,`BALANCE`,`VIP`,`ADDRESS`');
   });
 
   it('builds column names with true fields filter for SELECT', function() {
@@ -272,7 +302,7 @@ describe('sql connector', function() {
 
   it('builds column names with false fields filter for SELECT', function() {
     var cols = connector.buildColumnNames('customer', {fields: {name: false}});
-    expect(cols).to.eql('`VIP`,`ADDRESS`');
+    expect(cols).to.eql('`PREFERENCES`,`BALANCE`,`VIP`,`ADDRESS`');
   });
 
   it('builds column names with array fields filter for SELECT', function() {
@@ -297,11 +327,12 @@ describe('sql connector', function() {
   });
 
   it('builds SELECT', function() {
+    var cols = connector.buildColumnNames('customer');
     var sql = connector.buildSelect('customer',
       {order: 'name', limit: 5, where: {name: 'John'}});
     expect(sql.toJSON()).to.eql({
-      sql: 'SELECT `NAME`,`VIP`,`ADDRESS` FROM `CUSTOMER`' +
-      ' WHERE `NAME`=$1 ORDER BY `NAME` LIMIT 5',
+      sql: 'SELECT ' + cols +
+      ' FROM `CUSTOMER` WHERE `NAME`=$1 ORDER BY `NAME` LIMIT 5',
       params: ['John'],
     });
   });


### PR DESCRIPTION
Respect user specified datatypes for databases

 * support data types without length (eg: "jsonb")
 * support data types requiring precision (eg: "decimal (18,2)")

### Description
This was partially implemented but would only output data types when they had a length specified.  It also would not out put a precision if one was specified.  This rectifies both problems (and adds a test)

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->


### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
