### PR TITLE
Add ParameterizedSQL.prototype.collapse

### DIFF
--- a/lib/parameterized-sql.js
+++ b/lib/parameterized-sql.js
@@ -39,8 +39,39 @@ function ParameterizedSQL(sql, params) {
     'The number of ? (' + (parts.length - 1) +
     ') in the sql (' + this.sql + ') must match the number of params (' +
     this.params.length +
-    ') ' + this.params);
+         ') ' + this.params);
+  this.collapse();
 }
+
+/**
+ * Takes a tree of ParameterizedSQL objects (where some parameter values
+ * are other ParameterizedSQL) and reduce it to a single ParameterizedSQL
+ * object, by splicing params and sql together
+ * @returns {ParameterizedSQL} The current instance
+ */
+
+ParameterizedSQL.prototype.collapse = function collapse() {
+  var sfrom = 0;
+  var sidx = -1;
+  var sqlOut = '';
+  var pOut = [];
+  for (var pidx = 0; pidx < this.params.length; pidx++) {
+    var p = this.params[pidx];
+    sidx = this.sql.indexOf(PLACEHOLDER, sidx + 1);
+    if (!(p instanceof ParameterizedSQL && sidx > -1)) {
+      pOut.push(p);
+      continue;
+    }
+    p.collapse();
+    // replace the original ? with the sub sql and splice in the parameters
+    sqlOut += this.sql.substring(sfrom, sidx) + '(' + p.sql + ')';
+    sfrom = sidx + 1;
+    pOut = pOut.concat(p.params);
+  }
+  this.sql = sqlOut + this.sql.substring(sfrom);
+  this.params = pOut;
+  return this;
+};
 
 /**
  * Merge the parameterized sqls into the current instance
@@ -98,9 +129,9 @@ ParameterizedSQL.join = function(sqls, separator) {
   assert(Array.isArray(sqls), 'sqls must be an array');
   var ps = new ParameterizedSQL('', []);
   for (var i = 0, n = sqls.length; i < n; i++) {
-    this.append(ps, sqls[i], separator);
+    ParameterizedSQL.append(ps, sqls[i], separator);
   }
-  return ps;
+  return ps.collapse();
 };
 
 ParameterizedSQL.PLACEHOLDER = PLACEHOLDER;

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1146,16 +1146,8 @@ SQLConnector.prototype._buildWhere = function(model, where) {
     }
     whereStmts.push(stmt);
   }
-  var params = [];
-  var sqls = [];
-  for (var k = 0, s = whereStmts.length; k < s; k++) {
-    sqls.push(whereStmts[k].sql);
-    params = params.concat(whereStmts[k].params);
-  }
-  var whereStmt = new ParameterizedSQL({
-    sql: sqls.join(' AND '),
-    params: params,
-  });
+
+  var whereStmt = ParameterizedSQL.join(whereStmts, ' AND ');
   return whereStmt;
 };
 

--- a/test/parameterized-sql.test.js
+++ b/test/parameterized-sql.test.js
@@ -1,0 +1,92 @@
+// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Node module: loopback-connector
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+var expect = require('chai').expect;
+var SQLConnector = require('../lib/sql');
+var ParameterizedSQL = SQLConnector.ParameterizedSQL;
+
+/* eslint-disable one-var */
+var connector;
+var Customer;
+/* eslint-enable one-var */
+
+describe('ParameterizedSQL functionality', function() {
+  it('normalizes a SQL statement from string', function() {
+    var sql = 'SELECT * FROM `CUSTOMER`';
+    var stmt = new ParameterizedSQL(sql);
+    expect(stmt.toJSON()).to.eql({sql: sql, params: []});
+  });
+
+  it('normalizes a SQL statement from object without params', function() {
+    var sql = {sql: 'SELECT * FROM `CUSTOMER`'};
+    var stmt = new ParameterizedSQL(sql);
+    expect(stmt.toJSON()).to.eql({sql: sql.sql, params: []});
+  });
+
+  it('normalizes a SQL statement from object with params', function() {
+    var sql =
+    {sql: 'SELECT * FROM `CUSTOMER` WHERE `NAME`=?', params: ['John']};
+    var stmt = new ParameterizedSQL(sql);
+    expect(stmt.toJSON()).to.eql({sql: sql.sql, params: ['John']});
+  });
+
+  it('should throw if the statement is not a string or object', function() {
+    expect(function() {
+      /* jshint unused:false */
+      var stmt = new ParameterizedSQL(true);
+    }).to.throw('sql must be a string');
+  });
+
+  it('concats SQL statements', function() {
+    var stmt1 = {sql: 'SELECT * from `CUSTOMER`'};
+    var where = {sql: 'WHERE `NAME`=?', params: ['John']};
+    stmt1 = ParameterizedSQL.append(stmt1, where);
+    expect(stmt1.toJSON()).to.eql(
+      {sql: 'SELECT * from `CUSTOMER` WHERE `NAME`=?', params: ['John']});
+  });
+
+  it('concats string SQL statements', function() {
+    var stmt1 = 'SELECT * from `CUSTOMER`';
+    var where = {sql: 'WHERE `NAME`=?', params: ['John']};
+    stmt1 = ParameterizedSQL.append(stmt1, where);
+    expect(stmt1.toJSON()).to.eql(
+      {sql: 'SELECT * from `CUSTOMER` WHERE `NAME`=?', params: ['John']});
+  });
+
+  it('should throw if params does not match placeholders', function() {
+    expect(function() {
+      var stmt1 = 'SELECT * from `CUSTOMER`';
+      var where = {sql: 'WHERE `NAME`=?', params: ['John', 'Mary']};
+      stmt1 = ParameterizedSQL.append(stmt1, where);
+    }).to.throw('must match the number of params');
+  });
+
+  it('should collapse trees of parameterized queries', function() {
+    var sql1 = 'SELECT * from `CUSTOMER` WHERE `NAME` NOT IN ? AND `NAME` IN ?';
+    var sql2 = 'SELECT `NAME` FROM `CUSTOMER` WHERE ID = ? and `DELETED_ON` IS NULL';
+    var sql3 = 'SELECT `NAME` FROM `CUSTOMER` WHERE ID IN ?';
+    var sql4 = 'SELECT `CUSTOMER_ID` FROM `SPECIAL_DATE` WHERE ' +
+          'DATE=CURRENT_TIMESTAMP AND (`EVENTTYPE`=\'birthday\' OR 1=?)';
+    var expectssql = 'SELECT * from `CUSTOMER` WHERE `NAME` NOT IN (' +
+          sql2 + ') AND `NAME` IN (SELECT `NAME` FROM `CUSTOMER` WHERE ID IN (' +
+          sql4 + '))';
+
+    var p1 = new ParameterizedSQL({sql: sql2, params: [1]});
+    var p2 = new ParameterizedSQL({sql: sql3, params: [
+      new ParameterizedSQL({sql: sql4, params: [1]}),
+    ]});
+    var expectsparams = [1, 1];
+    var expects = {
+      sql: expectssql,
+      params: expectsparams,
+    };
+    var stmt = new ParameterizedSQL({
+      sql: sql1,
+      params: [p1, p2],
+    }).collapse();
+    expect(stmt.toJSON()).to.eql(expects);
+  });
+});

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -314,56 +314,6 @@ describe('sql connector', function() {
     });
   });
 
-  it('normalizes a SQL statement from string', function() {
-    var sql = 'SELECT * FROM `CUSTOMER`';
-    var stmt = new ParameterizedSQL(sql);
-    expect(stmt.toJSON()).to.eql({sql: sql, params: []});
-  });
-
-  it('normalizes a SQL statement from object without params', function() {
-    var sql = {sql: 'SELECT * FROM `CUSTOMER`'};
-    var stmt = new ParameterizedSQL(sql);
-    expect(stmt.toJSON()).to.eql({sql: sql.sql, params: []});
-  });
-
-  it('normalizes a SQL statement from object with params', function() {
-    var sql =
-    {sql: 'SELECT * FROM `CUSTOMER` WHERE `NAME`=?', params: ['John']};
-    var stmt = new ParameterizedSQL(sql);
-    expect(stmt.toJSON()).to.eql({sql: sql.sql, params: ['John']});
-  });
-
-  it('should throw if the statement is not a string or object', function() {
-    expect(function() {
-      /* jshint unused:false */
-      var stmt = new ParameterizedSQL(true);
-    }).to.throw('sql must be a string');
-  });
-
-  it('concats SQL statements', function() {
-    var stmt1 = {sql: 'SELECT * from `CUSTOMER`'};
-    var where = {sql: 'WHERE `NAME`=?', params: ['John']};
-    stmt1 = ParameterizedSQL.append(stmt1, where);
-    expect(stmt1.toJSON()).to.eql(
-      {sql: 'SELECT * from `CUSTOMER` WHERE `NAME`=?', params: ['John']});
-  });
-
-  it('concats string SQL statements', function() {
-    var stmt1 = 'SELECT * from `CUSTOMER`';
-    var where = {sql: 'WHERE `NAME`=?', params: ['John']};
-    stmt1 = ParameterizedSQL.append(stmt1, where);
-    expect(stmt1.toJSON()).to.eql(
-      {sql: 'SELECT * from `CUSTOMER` WHERE `NAME`=?', params: ['John']});
-  });
-
-  it('should throw if params does not match placeholders', function() {
-    expect(function() {
-      var stmt1 = 'SELECT * from `CUSTOMER`';
-      var where = {sql: 'WHERE `NAME`=?', params: ['John', 'Mary']};
-      stmt1 = ParameterizedSQL.append(stmt1, where);
-    }).to.throw('must match the number of params');
-  });
-
   it('should allow execute(sql, callback)', function(done) {
     connector.execute('SELECT * FROM `CUSTOMER`', done);
   });


### PR DESCRIPTION
### Description

 * use ParameterizedSQL.join instead of reimplementing in buildWheres
 * ParameterizedSQL.join collapses as its last step
 * in ParameterizedSQL.join, refer to .append statically for clarity
 * pulled ParameterizedSQL tests into their own file and added test
   for collapse

ParameterizedSQL.collapse allows things like nested subqueries as
select / from / where values, which allows much greater access to
underlying database features and constuction of more efficient
queries.

#### Present Considerations

Requires another PR to be pulled into loopback-datasource-juggler to be fully functional, but i think this is a good patch even if the other is not accepted, as it should ease building expression/clause trees

See: https://github.com/AccelerationNet/loopback-datasource-juggler/commit/7540b9943f08b54777be8252c907edb46a65debf


#### Future Considerations

I think it should also decrease the difficulty of building where
clauses because we can just build the tree as its presented and then
collapse it, rather than trying to build the SQL as we traverse it.

#### Example
```
  Mymodel.forUser = async function (userid) {
    userid = Number(userid)
    var clause = "SELECT (jsonb_array_elements(preferences->'mymodelids_ids')"+
          "::text)::int \"mymodels\" FROM public.user WHERE public.user.id=? ";
    clause = new ParameterizedSQL(clause, [userid]);
    log.debug('Getting mymodels for a user', userid);
    var mymodels = await Mymodel.find({where: {id: { 'inq': clause}}});
    log.debug('Got mymodels: ', mymodels.length);
    return mymodels;
  };
```

#### Related issues

- None

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
