### PR TITLE
multiple ALTER TABLE statements should be separated by a comma instead of a space

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -200,7 +200,8 @@ SQLConnector.prototype.applySqlChanges = function(model, pendingChanges, cb) {
   var self = this;
   if (pendingChanges.length) {
     var thisQuery = 'ALTER TABLE ' + self.tableEscaped(model) +
-                    ' ' + pendingChanges.join(',\n');
+                    ' ' + pendingChanges.join(",\n");
+    thisQuery = thisQuery.replace(/[\s,]+$/, '');
     self.execute(thisQuery, cb);
   }
 };

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -199,15 +199,8 @@ SQLConnector.prototype.propertyHasNotBeenDeleted = function(model, propName) {
 SQLConnector.prototype.applySqlChanges = function(model, pendingChanges, cb) {
   var self = this;
   if (pendingChanges.length) {
-    var thisQuery = 'ALTER TABLE ' + self.tableEscaped(model);
-    var ranOnce = false;
-    pendingChanges.forEach(function(change) {
-      if (ranOnce) {
-        thisQuery = thisQuery + ' ';
-      }
-      thisQuery = thisQuery + ' ' + change;
-      ranOnce = true;
-    });
+    var thisQuery = 'ALTER TABLE ' + self.tableEscaped(model) +
+                    ' ' + pendingChanges.join(',\n');
     self.execute(thisQuery, cb);
   }
 };

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -200,8 +200,9 @@ SQLConnector.prototype.applySqlChanges = function(model, pendingChanges, cb) {
   var self = this;
   if (pendingChanges.length) {
     var thisQuery = 'ALTER TABLE ' + self.tableEscaped(model) +
-                    ' ' + pendingChanges.join(",\n");
+                    ' ' + pendingChanges.join(',\n');
     thisQuery = thisQuery.replace(/[\s,]+$/, '');
+    thisQuery = thisQuery.replace(/,\s*,/, ',\n');
     self.execute(thisQuery, cb);
   }
 };


### PR DESCRIPTION
### Description

I ran into this issue when testing foreignKey migration with the newest version of loopback-connector-mysql. When declaring multiple foreign keys, I get an SQL syntax error. I traced it down to loopback-connector's `applySqlChanges` method.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
