### PR TITLE
Avoid duplicate column restriction in where

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1159,7 +1159,12 @@ SQLConnector.prototype._buildWhere = function(model, where) {
         }
       }
     }
-    whereStmts.push(stmt);
+    var columnRestricted = false;
+    whereStmts.forEach(function(stmt) {
+      if (columnRestricted) return;
+      columnRestricted = stmt.sql.indexOf(columnName) >= 0;
+    });
+    if (!columnRestricted) whereStmts.push(stmt);
   }
   var params = [];
   var sqls = [];


### PR DESCRIPTION
### Description

Avoid to add a duplicate column restriction to where clause

#### Related issues
https://github.com/strongloop-internal/scrum-asteroid/issues/86
<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
