### PR TITLE
Fix postgresql transaction

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -85,7 +85,7 @@ Transaction.begin = function(connector, options, cb) {
       return cb(err);
     }
     var tx = connection;
-    if (!(connection instanceof Transaction)) {
+    if (!(connection instanceof Transaction) && !(typeof connection.txId === 'string')) {
       tx = new Transaction(connector, connection);
     }
     cb(err, tx);


### PR DESCRIPTION
connected to https://github.com/strongloop/loopback-connector-postgresql/issues/258

### Description
Original problem: https://github.com/strongloop/loopback-connector-postgresql/issues/258
When calling `beginTransaction`, an error would occur saying `Transaction is not active`.

#### Related issues
Related discussion/PR: https://github.com/strongloop/loopback-connector-postgresql/pull/268

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes 
   - test will be added through https://github.com/strongloop/loopback-connector-postgresql/pull/268
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)


cc @jannyHou @zbarbuto