### PR TITLE
Fix Postgresql transaction

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -85,7 +85,13 @@ Transaction.begin = function(connector, options, cb) {
       return cb(err);
     }
     var tx = connection;
-    if (!(connection instanceof Transaction)) {
+
+    // When the connector and juggler node module have different version of this module as a dependency,
+    // the transaction is not an instanceof Transaction.
+    // i.e. (connection instanceof Transaction) == false
+    // Check for existence of required functions and properties, instead of prototype inheritance.
+    if (connection.connector == undefined || connection.connection == undefined ||
+      connection.commit == undefined || connection.rollback == undefined) {
       tx = new Transaction(connector, connection);
     }
     cb(err, tx);


### PR DESCRIPTION
### Description

Original problem: strongloop/loopback-connector-postgresql#258
When calling beginTransaction, an error would occur saying Transaction is not active.

The cause of the problem is the connector (postgresql in this case) and juggler modules are pointing to a different version of connector.  It makes the check for the instance of Transaction failed. 
More details of explanation from @jannyHou can be found here: https://github.com/strongloop/loopback-connector-postgresql/pull/268#issuecomment-311388408

The fix (as suggested by @kjdelisle) is to have a softer check on the transaction.  i.e. to check for the existence of the `connector` and `connection` properties and `commit` & `rollback` function. 

connect to strongloop/loopback-connector-postgresql#258

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
