### PR TITLE
Add CODEOWNER file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners,
+# the last matching pattern has the most precendence.
+
+# Core team members from IBM
+* @kjdelisle @jannyHou @loay @b-admike @ssh24 @virkt25 @dhmlau


### PR DESCRIPTION
Add CODEOWNER file

New feature in github allows us to specify the owner of the repo. https://github.com/blog/2392-introducing-code-owners
We can make this to replace the repo owner wiki page: https://github.com/strongloop-internal/loopback-knowledge-base/wiki/Repo-owners

connect to strongloop-internal/scrum-apex/issues/278
