### PR TITLE
Support transactions in count()

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1518,7 +1518,7 @@ SQLConnector.prototype.count = function(model, where, options, cb) {
     this.tableEscaped(model));
   stmt = stmt.merge(this.buildWhere(model, where));
   stmt = this.parameterize(stmt);
-  this.execute(stmt.sql, stmt.params,
+  this.execute(stmt.sql, stmt.params, options,
     function(err, res) {
       if (err) {
         return cb(err);

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -92,19 +92,25 @@ describe('transactions', function() {
         function(err, posts) {
           if (err) return done(err);
           expect(posts.length).to.be.eql(count);
-          if (count) {
-            // Find related reviews
-            options.model = 'Review';
-            // Please note the empty {} is required, otherwise, the options
-            // will be treated as a filter
-            posts[0].reviews({}, options, function(err, reviews) {
+          // Make sure both find() and count() behave the same way
+          Post.count(where, options,
+            function(err, result) {
               if (err) return done(err);
-              expect(reviews.length).to.be.eql(count);
-              done();
+              expect(result).to.be.eql(count);
+              if (count) {
+                // Find related reviews
+                options.model = 'Review';
+                // Please note the empty {} is required, otherwise, the options
+                // will be treated as a filter
+                posts[0].reviews({}, options, function(err, reviews) {
+                  if (err) return done(err);
+                  expect(reviews.length).to.be.eql(count);
+                  done();
+                });
+              } else {
+                done();
+              }
             });
-          } else {
-            done();
-          }
         });
     };
   }


### PR DESCRIPTION
### Description

When passing on a transaction object to connector.count(), it does not currently get passed on internally to the SQL `execute()` method, meaning that the count of the table outside the transaction will be counted and a wrong result will be returned.

This simple change fixes that. 

I will add a unit test for it in https://github.com/strongloop/loopback-connector-postgresql

#### Related issues

- None

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
