### PR TITLE
Part 2 of moving tx timeout and id to connector

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -8,6 +8,7 @@ var assert = require('assert');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var debug = require('debug')('loopback:connector:transaction');
+var uuid = require('uuid');
 
 module.exports = Transaction;
 
@@ -93,6 +94,27 @@ Transaction.begin = function(connector, options, cb) {
     if (connection.connector == undefined || connection.connection == undefined ||
       connection.commit == undefined || connection.rollback == undefined) {
       tx = new Transaction(connector, connection);
+    }
+    // Set an informational transaction id
+    tx.id = uuid.v1();
+    // NOTE(lehni) Handling of transaction timeouts here only works with recent
+    // versions of `loopback-datasource-juggler` which make its own handling of
+    // timeouts conditional based on the absence of an already set `tx.timeout`,
+    // see: https://github.com/strongloop/loopback-datasource-juggler/pull/1484
+    if (options.timeout) {
+      tx.timeout = setTimeout(function() {
+        var context = {
+          transaction: tx,
+          operation: 'timeout',
+        };
+        tx.notifyObserversOf('timeout', context, function(err) {
+          if (!err) {
+            tx.rollback(function() {
+              debug('Transaction %s is rolled back due to timeout', tx.id);
+            });
+          }
+        });
+      }, options.timeout);
     }
     cb(err, tx);
   });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "bluebird": "^3.4.6",
     "debug": "^2.2.0",
     "msgpack5": "^3.4.1",
-    "strong-globalize": "^2.5.8"
+    "strong-globalize": "^2.5.8",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "chai": "~3.5.0",


### PR DESCRIPTION
### Description

As outlined in strongloop/loopback-datasource-juggler#1484, this simple PR is part two of moving the handling of transaction timeouts and ids from `loopback-datasource-juggler`'s [`TransactionMixin.beginTransaction()`](https://github.com/strongloop/loopback-datasource-juggler/blob/3b45c76d0fd3364c55a55720d685b5596fb578d1/lib/transaction.js#L73-L108) to `loopback-connector`'s [`Transaction.begin()`](https://github.com/strongloop/loopback-connector/blob/fd7d5db2c88295ed695162d906220f722a628293/lib/transaction.js#L66-L99), where it makes more sense and can be leveraged more easily by other parts of the code, e.g. the work I am doing in strongloop/loopback-datasource-juggler#1472. For a more detailed description of the motivation to do so, see https://github.com/strongloop/loopback-datasource-juggler/pull/1472#issuecomment-324613756

I don't think additional tests are required, since there already is an existing test for transaction timeouts, which will fail until strongloop/loopback-datasource-juggler#1484 has been merged.

#### Related issues

- strongloop/loopback-datasource-juggler#1484
- strongloop/loopback-datasource-juggler#1472

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
