### PR TITLE
transaction.test: fix duplicate calls in timeout

### DIFF
--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -182,22 +182,18 @@ describe('transactions', function() {
     before(createPostInTx(post, 50));
 
     it('should report timeout', function(done) {
-      setTimeout(function() {
-        Post.find({where: {title: 't3'}}, {transaction: currentTx},
-          function(err, posts) {
-            if (err) return done(err);
-            expect(posts.length).to.be.eql(1);
-            done();
-          });
-      }, 300);
-      done();
-    });
-
-    it('should invoke the timeout hook', function(done) {
-      currentTx.observe('timeout', function(context, next) {
+      this.timeout(300);
+      function observer(context, next) {
+        // Prevent duplicate calls to this handler.
+        currentTx.removeObserver('timeout', observer);
         next();
         done();
-      });
+      }
+      currentTx.observe('timeout', observer);
+      setTimeout(function() {
+        Post.find({where: {title: 't3'}}, {transaction: currentTx},
+          function() {});
+      }, 300);
     });
   });
 


### PR DESCRIPTION
### Description

Multiple handlers throughout the code base call the timeout
event, which triggers multiple calls to the observer function
under test, causing issues in Mocha.

The test now asserts against a single call to the timeout observer
and then unwires it before ending the test.

#### Related issues
connected to #116 
connected to strongloop/loopback-datasource-juggler/pull/1472
### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
