### PR TITLE
Autoupdate in series instead of concurrently.

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -75,7 +75,7 @@ SQLConnector.prototype.autoupdate = function(models, cb) {
 
   models = models || Object.keys(this._models);
 
-  async.each(models, function(model, done) {
+  async.eachSeries(models, function(model, done) {
     if (!(model in self._models)) {
       return process.nextTick(function() {
         done(new Error(g.f('Model not found: %s', model)));
@@ -1583,7 +1583,7 @@ SQLConnector.prototype.automigrate = function(models, cb) {
     });
   }
 
-  async.each(models, function(model, done) {
+  async.eachSeries(models, function(model, done) {
     self.dropTable(model, function(err) {
       if (err) {
         // TODO(bajtos) should we abort here and call cb(err)?


### PR DESCRIPTION
### Description
I've been seeing this error sometimes in a project I've been working on:

```
duplicate key value violates unique constraint "pg_namespace_nspname_index"
```

A quick search leads to this stack overflow answer:

https://stackoverflow.com/a/29908840

The answer recommends that DDLs not be done concurrently. I think I've been seeing this error because I have a couple of models in a schema other than public, and automigrate is attempting to create the same schema concurrently.

This commit simply switches out `async.each` for `async.eachSeries` when altering the schema, so each DDL is allowed to finish before the next one runs.

Since this only changes non-deterministic behavior, no tests were added as it's very hard to reproduce reliably.

This was also implemented for loopback 2.x: https://github.com/strongloop/loopback-connector-postgresql/pull/315

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
