### PR TITLE
Allow empty array or value of `order`

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1216,6 +1216,9 @@ SQLConnector.prototype.buildOrderBy = function(model, order) {
       clauses.push(self.columnEscaped(model, t[0]) + ' ' + t[1]);
     }
   }
+  if (!clauses.length) {
+    return '';
+  }
   return 'ORDER BY ' + clauses.join(',');
 };
 

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -270,6 +270,16 @@ describe('sql connector', function() {
     expect(orderBy).to.eql('ORDER BY `NAME` ASC,`VIP` DESC');
   });
 
+  it('builds order by with empty array', function() {
+    const orderBy = connector.buildOrderBy('customer', []);
+    expect(orderBy).to.eql('');
+  });
+
+  it('builds order by with empty string', function() {
+    const orderBy = connector.buildOrderBy('customer', '');
+    expect(orderBy).to.eql('');
+  });
+
   it('builds fields for columns', function() {
     const fields = connector.buildFields('customer',
       {name: 'John', vip: true, unknown: 'Random'});


### PR DESCRIPTION
### Description

Empty array of `order` creates invalid SQL without this change.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
