### PR TITLE
fix: reject filter objects in destroyAll method

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -780,7 +780,11 @@ SQLConnector.prototype.buildDelete = function(model, where, options) {
  * @param {Function} cb The callback function
  */
 SQLConnector.prototype.destroyAll = function(model, where, options, cb) {
-  var stmt = this.buildDelete(model, where, options);
+  try {
+    var stmt = this.buildDelete(model, where, options);
+  } catch (err) {
+    return cb(err);
+  }
   this._executeAlteringQuery(model, stmt.sql, stmt.params, options, cb || NOOP);
 };
 
@@ -1091,6 +1095,15 @@ SQLConnector.prototype._buildWhere = function(model, where) {
         continue;
       }
       // The value is not an array, fall back to regular fields
+    }
+
+    if (key === 'where') {
+      // business as usual if the model has a property named 'where'
+      if (props[key]) {
+        continue;
+      } else {
+        throw new Error('Filter object detected. Please use a where object instead.');
+      }
     }
     var p = props[key];
     if (p == null) {

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1097,19 +1097,11 @@ SQLConnector.prototype._buildWhere = function(model, where) {
       // The value is not an array, fall back to regular fields
     }
 
-    if (key === 'where') {
-      // business as usual if the model has a property named 'where'
-      if (props[key]) {
-        continue;
-      } else {
-        throw new Error('Filter object detected. Please use a where object instead.');
-      }
-    }
     var p = props[key];
     if (p == null) {
-      // Unknown property, ignore it
-      debug('Unknown property %s is skipped for model %s', key, model);
-      continue;
+      throw new Error(
+        `Unknown property ${key} used in a "where" condition for model ${model}`
+      );
     }
     // eslint-disable one-var
     var expression = where[key];


### PR DESCRIPTION
### Description
Connect to https://github.com/strongloop/loopback-datasource-juggler/pull/1597 and https://github.com/strongloop/loopback/issues/3094. The first commit ensures that we reject filter objects passed on to the `destroyAll` method. This should be applicable to all the SQL connectors.

**EDIT**: The second commit ensures that we reject objects with keys that are not part of the model properties in `destroyAll` method. This should be applicable to all the SQL connectors.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
