### PR TITLE
Fix bad where

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1182,6 +1182,7 @@ SQLConnector.prototype._buildWhere = function(model, where) {
   let params = [];
   const sqls = [];
   for (let k = 0, s = whereStmts.length; k < s; k++) {
+    if (!whereStmts[k].sql) continue;
     sqls.push(whereStmts[k].sql);
     params = params.concat(whereStmts[k].params);
   }

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -247,6 +247,14 @@ describe('sql connector', function() {
     });
   });
 
+  it('builds where and ignores invalid clauses in or', function() {
+    const where = connector.buildWhere('customer', {
+      name: 'icecream',
+      or: [{notAColumnName: ''}, {notAColumnNameEither: ''}],
+    });
+    expect(where.sql).to.not.match(/ AND $/);
+  });
+
   it('builds order by with one field', function() {
     const orderBy = connector.buildOrderBy('customer', 'name');
     expect(orderBy).to.eql('ORDER BY `NAME`');


### PR DESCRIPTION
### Description
When building an array of WHERE statements to join with AND, do not include empty statements.

#### Related issues

Fixes #133 

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
