### PR TITLE
feat: map property name to table column name (SQL only)

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -382,6 +382,9 @@ SQLConnector.prototype.column = function(model, property) {
       return columnName;
     }
   }
+  if (prop && prop.name) {
+    return prop.name;
+  }
   columnName = property;
   if (typeof this.dbName === 'function') {
     columnName = this.dbName(columnName);

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -34,13 +34,28 @@ describe('sql connector', function() {
             dataType: 'VARCHAR',
             dataLength: 32,
           },
-        }, vip: {
+        },
+        vip: {
           type: Boolean,
           testdb: {
             column: 'VIP',
           },
         },
         address: String,
+        shippingAddress: {
+          type: String,
+          testdb: {
+            columnName: 'SHIPPING_ADDRESS',
+            dataType: 'VARCHAR',
+          },
+        },
+        billingAddress: {
+          name: 'BILLING_ADDRESS',
+          type: String,
+          testdb: {
+            dataType: 'VARCHAR',
+          },
+        },
       },
       {testdb: {table: 'CUSTOMER'}});
   });
@@ -53,6 +68,16 @@ describe('sql connector', function() {
   it('should map column name', function() {
     var column = connector.column('customer', 'name');
     expect(column).to.eql('NAME');
+  });
+
+  it('should map column name to columnName', function() {
+    var column = connector.column('customer', 'shippingAddress');
+    expect(column).to.eql('SHIPPING_ADDRESS');
+  });
+
+  it('should map column name to property name', function() {
+    var column = connector.column('customer', 'billingAddress');
+    expect(column).to.eql('BILLING_ADDRESS');
   });
 
   it('should find column metadata', function() {
@@ -262,7 +287,9 @@ describe('sql connector', function() {
 
   it('builds column names for SELECT', function() {
     var cols = connector.buildColumnNames('customer');
-    expect(cols).to.eql('`NAME`,`VIP`,`ADDRESS`');
+    expect(cols).to.eql(
+      '`NAME`,`VIP`,`ADDRESS`,`SHIPPING_ADDRESS`,`BILLING_ADDRESS`'
+    );
   });
 
   it('builds column names with true fields filter for SELECT', function() {
@@ -272,7 +299,7 @@ describe('sql connector', function() {
 
   it('builds column names with false fields filter for SELECT', function() {
     var cols = connector.buildColumnNames('customer', {fields: {name: false}});
-    expect(cols).to.eql('`VIP`,`ADDRESS`');
+    expect(cols).to.eql('`VIP`,`ADDRESS`,`SHIPPING_ADDRESS`,`BILLING_ADDRESS`');
   });
 
   it('builds column names with array fields filter for SELECT', function() {
@@ -300,7 +327,8 @@ describe('sql connector', function() {
     var sql = connector.buildSelect('customer',
       {order: 'name', limit: 5, where: {name: 'John'}});
     expect(sql.toJSON()).to.eql({
-      sql: 'SELECT `NAME`,`VIP`,`ADDRESS` FROM `CUSTOMER`' +
+      sql: 'SELECT `NAME`,`VIP`,`ADDRESS`,`SHIPPING_ADDRESS`,`BILLING_ADDRESS` ' +
+      'FROM `CUSTOMER`' +
       ' WHERE `NAME`=$1 ORDER BY `NAME` LIMIT 5',
       params: ['John'],
     });


### PR DESCRIPTION
### Description
Update to allow column name to be set from model property name 

In addition to `column` and `columnName` now the model property `name` can be used to define the column name of the datasource table.

#### Related issues

- connect to https://github.com/strongloop/loopback-next/issues/1837

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
