### PR TITLE
fix: return undefined for first level undefined props

### DIFF
--- a/lib/connector.js
+++ b/lib/connector.js
@@ -155,20 +155,24 @@ Connector.getNestedPropertyDefinition = function(definition, propPath) {
   const isArray = !isPropUndefined && Array.isArray(prop.type);
   const isFunction = !isPropUndefined && !isArray && typeof prop.type === 'function';
 
-  if (isPropUndefined || (propPath.length > 1 && (isArray && prop.type.length === 0))) {
-    throw new Error(g.f('Invalid property path'));
-  }
-
   if (propPath.length === 1) return prop;
+
+  if (isPropUndefined || (propPath.length > 1 && (isArray && prop.type.length === 0))) {
+    return undefined;
+  }
 
   const nextDefinition =
     (isArray && prop.type[0].definition) ||
     (isFunction && prop.type.definition);
 
-  return Connector.getNestedPropertyDefinition(
-    nextDefinition,
-    propPath.slice(1)
-  );
+  if (nextDefinition === undefined) {
+    return undefined;
+  } else {
+    return Connector.getNestedPropertyDefinition(
+      nextDefinition,
+      propPath.slice(1)
+    );
+  }
 };
 
 /**

--- a/test/connector.test.js
+++ b/test/connector.test.js
@@ -96,12 +96,17 @@ describe('Connector', () => {
       expect(propDefinition.type).to.equal(Date);
     });
 
-    it('should fail for non-existing properties', () => {
-      expect(() =>
-        connector.getPropertyDefinition(
-          'MyModel',
-          'non.existing.property'
-        )).to.throw(/Invalid property path/);
+    it('should return undefined for non-existing nested property', () => {
+      const definition = connector.getPropertyDefinition('MyModel',
+        'someProp.innerArray.foo');
+      // eslint-disable-next-line no-unused-expressions
+      expect(definition).to.be.undefined;
+    });
+
+    it('should preserve backward-compatibility for non-existing property', () => {
+      const definition = connector.getPropertyDefinition('MyModel', 'idontexist');
+      // eslint-disable-next-line no-unused-expressions
+      expect(definition).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
### Description
Keep backward-compatilibity from #136 so that for first level properties, we return what we did before.

Fixes https://github.com/strongloop/loopback-connector-postgresql/issues/364


### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
