### PR TITLE
FIX: 'Model.create' doesn't return an autogenerated 'id' property

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -426,12 +426,7 @@ SQLConnector.prototype.propertyName = function(model, column) {
  * @returns {String} The id column name
  */
 SQLConnector.prototype.idColumn = function(model) {
-  var name = this.getDataSource(model).idColumnName(model);
-  var dbName = this.dbName;
-  if (typeof dbName === 'function') {
-    name = dbName(name);
-  }
-  return name;
+  return this.getDataSource(model).idColumnName(model);
 };
 
 /**


### PR DESCRIPTION
### Description
According to my project naming convention, the "id" property has to be "Id" - the first letter is capital.
The model definition allows me doing that:
```
"Id": {
	"type": "number",
	"id": 1,
	"generated": true,
	"postgresql": {
		"columnName": "Id",
		"dataType": "integer",
		"nullable": "NO"
	}
},
```

It did look that it worked fine, however, I noticed that after `Model.create` method is executed, the returning object has all the properties but the "Id"!

#### Related issues
- connect to strongloop/loopback-connector-postgresql#366
- connect to https://stackoverflow.com/questions/42621993/how-to-get-auto-id-after-upsert-on-a-persisted-model-in-loopback

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->



### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
