### PR TITLE
chore: add promise support

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -9,6 +9,7 @@ var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var debug = require('debug')('loopback:connector:transaction');
 var uuid = require('uuid');
+const {createPromiseCallback} = require('./utils');
 
 module.exports = Transaction;
 
@@ -46,7 +47,13 @@ Transaction.hookTypes = {
  * @returns {*}
  */
 Transaction.prototype.commit = function(cb) {
-  return this.connector.commit(this.connection, cb);
+  cb = cb || createPromiseCallback();
+  if (cb.promise) {
+    this.connector.commit(this.connection, cb);
+    return cb.promise;
+  } else {
+    return this.connector.commit(this.connection, cb);
+  }
 };
 
 /**
@@ -55,7 +62,13 @@ Transaction.prototype.commit = function(cb) {
  * @returns {*|boolean}
  */
 Transaction.prototype.rollback = function(cb) {
-  return this.connector.rollback(this.connection, cb);
+  cb = cb || createPromiseCallback();
+  if (cb.promise) {
+    this.connector.rollback(this.connection, cb);
+    return cb.promise;
+  } else {
+    return this.connector.rollback(this.connection, cb);
+  }
 };
 
 /**
@@ -69,6 +82,7 @@ Transaction.begin = function(connector, options, cb) {
     cb = options;
     options = {};
   }
+  cb = cb || createPromiseCallback();
   if (typeof options === 'string') {
     options = {isolationLevel: options};
   }
@@ -118,4 +132,5 @@ Transaction.begin = function(connector, options, cb) {
     }
     cb(err, tx);
   });
+  if (cb.promise) return cb.promise;
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "uuid": "^3.0.1"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^4.19.1",
     "eslint-config-loopback": "^10.0.0",
     "loopback-datasource-juggler": "^3.12.0",

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -6,7 +6,10 @@
 'use strict';
 var Transaction = require('../index').Transaction;
 
-var expect = require('chai').expect;
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+const {expect} = chai;
+const chaiAsPromised = require('chai-as-promised');
 var testConnector = require('./connectors/test-sql-connector');
 
 var juggler = require('loopback-datasource-juggler');
@@ -246,5 +249,33 @@ describe('transactions', function() {
             });
         });
       });
+  });
+
+  it('can return promise for commit', function() {
+    const connectorObject = {};
+    connectorObject.commit = function(connection, cb) {
+      return cb(null, 'committed');
+    };
+    const transactionInstance = new Transaction(connectorObject, {});
+    return expect(transactionInstance.commit()).to.eventually.equal('committed');
+  });
+
+  it('can return promise for rollback', function() {
+    const connectorObject = {};
+    connectorObject.rollback = function(connection, cb) {
+      return cb(null, 'rolledback');
+    };
+    const transactionInstance = new Transaction(connectorObject, {});
+    return expect(transactionInstance.rollback()).to.eventually.equal('rolledback');
+  });
+
+  it('can return promise for begin', function() {
+    const connectorObject = {};
+    connectorObject.beginTransaction = function(connection, cb) {
+      return cb(null, 'begun');
+    };
+
+    return expect(Transaction.begin(connectorObject, '')
+    ).to.eventually.be.instanceOf(Transaction);
   });
 });


### PR DESCRIPTION
### Description

Add promise support to transaction class methods.

#### Related issues

- Connect to https://github.com/strongloop/loopback-next/issues/2614.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
