### PR TITLE
fix: prevent adding listeners past limit

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -623,9 +623,22 @@ SQLConnector.prototype.execute = function(sql, params, options, callback) {
 
   const self = this;
   if (!this.dataSource.connected) {
-    return this.dataSource.once('connected', function() {
-      self.execute(sql, params, options, callback);
-    });
+    // Prevent adding too many listeners to the 'connected' event on the datasource.
+    if (this.dataSource.listenerCount('connected') <
+        this.dataSource.getMaxOfflineRequests()) {
+      // allow this listener to be added to this event
+      return this.dataSource.once('connected', function() {
+        self.execute(sql, params, options, callback);
+      });
+    } else {
+      const limitReachedError = new Error(
+        g.f(
+          'Event listener limit reached. ' +
+            'Increase maxOfflineRequests value in datasources.json.',
+        ),
+      );
+      callback(limitReachedError);
+    }
   }
   const context = {
     req: {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "chai-as-promised": "^7.1.1",
     "eslint": "^6.1.0",
     "eslint-config-loopback": "^13.1.0",
-    "loopback-datasource-juggler": "^3.12.0",
+    "loopback-datasource-juggler": "^3.32.0",
     "mocha": "^6.2.0"
   }
 }

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -459,4 +459,40 @@ describe('sql connector', function() {
       done(err, results);
     });
   });
+
+  it('should throw if the event listener limit is reached', function() {
+    ds.connected = false;
+    function runExecute() {
+      return connector.execute('SELECT * FROM `CUSTOMER`', function(err) {
+        throw err;
+      });
+    }
+
+    for (let i = 0; i < 16; i++) {
+      runExecute();
+    }
+
+    expect(function() { runExecute(); }).to.throw(
+      'Event listener limit reached. ' +
+        'Increase maxOfflineRequests value in datasources.json.',
+    );
+    ds.connected = true;
+    ds.removeAllListeners(['connected']);
+  });
+
+  it('should not throw if the event listener limit is not reached', function() {
+    ds.connected = false;
+    function runExecute() {
+      return connector.execute('SELECT * FROM `CUSTOMER`', function(err) {
+        throw err;
+      });
+    }
+
+    for (let i = 0; i < 15; i++) {
+      runExecute();
+    }
+
+    expect(function() { runExecute(); }).to.not.throw();
+    ds.connected = true;
+  });
 });


### PR DESCRIPTION
### Description

Prevent adding listeners to 'connected' event past the limit established in the 
datasource.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-next/issues/2198

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
