### PR TITLE
fix syntax issue causing failure on older versions of nodeJS

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -634,8 +634,8 @@ SQLConnector.prototype.execute = function(sql, params, options, callback) {
       const limitReachedError = new Error(
         g.f(
           'Event listener limit reached. ' +
-            'Increase maxOfflineRequests value in datasources.json.',
-        ),
+            'Increase maxOfflineRequests value in datasources.json.'
+        )
       );
       callback(limitReachedError);
     }


### PR DESCRIPTION
### Description

Running the connector in node v7 and v8 failed due to the trailing commas. Later versions of nodeJS would ignore the syntax issue.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
