### PR TITLE
chore: remove unstable connectors from downstream list

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "ci": {
     "downstreamIgnoreList": [
       "loopback-connector-db2z",
+      "loopback-connector-ibmi",
       "loopback-connector-informix",
       "loopback-connector-mqlight",
       "loopback-connector-kv-extreme-scale"

--- a/package.json
+++ b/package.json
@@ -38,5 +38,13 @@
     "eslint-config-loopback": "^13.1.0",
     "loopback-datasource-juggler": "^3.32.0",
     "mocha": "^6.2.0"
+  },
+  "ci": {
+    "downstreamIgnoreList": [
+      "loopback-connector-db2z",
+      "loopback-connector-informix",
+      "loopback-connector-mqlight",
+      "loopback-connector-kv-extreme-scale"
+    ]
   }
 }


### PR DESCRIPTION
Configure cis-jenkins CI build to ignore the following repositories
when deciding which downstream projects to build:

 - loopback-connector-db2z
 - loopback-connector-informix
 - loopback-connector-mqlight
 - loopback-connector-kv-extreme-scale

The list is the same as we have in loopback-datasource-juggler now.

Additionally, we are removing loopback-connector-ibmi too, because we don't have any database instance to use for CI builds (yet).

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector) 👈

- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
