### PR TITLE
[will be closed]feat: add is active check for transaction

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -134,3 +134,10 @@ Transaction.begin = function(connector, options, cb) {
   });
   if (cb.promise) return cb.promise;
 };
+
+/**
+ * Check whether a transaction has an active connection.
+ */
+Transaction.prototype.isActive = function() {
+  return !!this.connection;
+}

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -210,6 +210,32 @@ describe('transactions', function() {
     });
   });
 
+  describe('isActive', function() {
+    it('returns true when connection is active', function(done) {
+      Post.beginTransaction({
+        isolationLevel: Transaction.READ_COMMITTED,
+        timeout: 1000,
+      },
+      function(err, tx) {
+        if (err) return done(err);
+        expect(tx.isActive()).to.equal(true);
+        return done();
+      });
+    });
+    it('returns false when connection is not active', function(done) {
+      Post.beginTransaction({
+        isolationLevel: Transaction.READ_COMMITTED,
+        timeout: 1000,
+      },
+      function(err, tx) {
+        if (err) return done(err);
+        delete tx.connection;
+        expect(tx.isActive()).to.equal(false);
+        return done();
+      });
+    });
+  });
+
   describe('transaction instance', function() {
     function TestTransaction(connector, connection) {
       this.connector = connector;


### PR DESCRIPTION
This PR will be closed in favor of #164 and #165 
Implements https://github.com/strongloop/loopback-next/issues/3471

My tests fail due to a circular dependency: there is another `loopback-connector` installed inside `node_modules` in parallel with `loopback-datasource-juggler` and therefore `loopback-datasource-juggler`  uses its own `loopback-connector` as dependency instead of my code. So I may have to release the `isActive` function first to get tests pass.

UPDATE: It's bad to merge failed PR, so I break down this PR into two: 

- code https://github.com/strongloop/loopback-connector/pull/164
- test https://github.com/strongloop/loopback-connector/pull/165

Merge and release the code first then merge the test.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
