### PR TITLE
isactive test

### DIFF
--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -210,6 +210,32 @@ describe('transactions', function() {
     });
   });
 
+  describe('isActive', function() {
+    it('returns true when connection is active', function(done) {
+      Post.beginTransaction({
+        isolationLevel: Transaction.READ_COMMITTED,
+        timeout: 1000,
+      },
+      function(err, tx) {
+        if (err) return done(err);
+        expect(tx.isActive()).to.equal(true);
+        return done();
+      });
+    });
+    it('returns false when connection is not active', function(done) {
+      Post.beginTransaction({
+        isolationLevel: Transaction.READ_COMMITTED,
+        timeout: 1000,
+      },
+      function(err, tx) {
+        if (err) return done(err);
+        delete tx.connection;
+        expect(tx.isActive()).to.equal(false);
+        return done();
+      });
+    });
+  });
+
   describe('transaction instance', function() {
     function TestTransaction(connector, connection) {
       this.connector = connector;


### PR DESCRIPTION
Break down the PR https://github.com/strongloop/loopback-connector/pull/163 into a code PR + a test PR. See the reason:

My tests fail due to a circular dependency: there is another loopback-connector installed inside node_modules in parallel with loopback-datasource-juggler and therefore loopback-datasource-juggler uses its own loopback-connector as dependency instead of my code. So I may have to release the isActive function first to get tests pass.

**This is the TEST PR**
code PR see #164 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
