### PR TITLE
chore: update copyright year

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2019. All Rights Reserved.
+// Copyright IBM Corp. 2015,2020. All Rights Reserved.
 // Node module: loopback-connector
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2019. All Rights Reserved.
+// Copyright IBM Corp. 2015,2020. All Rights Reserved.
 // Node module: loopback-connector
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT


### PR DESCRIPTION
Related: strongloop-internal/scrum-apex#440

Update the copyrights year in the rest of the packages besides #4596.

The changes are introduced by running the `slt copyright` command. 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
