### PR TITLE
fix: run migrations in series

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -75,7 +75,7 @@ SQLConnector.prototype.autoupdate = function(models, cb) {
 
   models = models || Object.keys(this._models);
 
-  async.each(models, function(model, done) {
+  async.eachSeries(models, function(model, done) {
     if (!(model in self._models)) {
       return process.nextTick(function() {
         done(new Error(g.f('Model not found: %s', model)));
@@ -1600,7 +1600,7 @@ SQLConnector.prototype.automigrate = function(models, cb) {
     });
   }
 
-  async.each(models, function(model, done) {
+  async.eachSeries(models, function(model, done) {
     self.dropTable(model, function(err) {
       if (err) {
         // TODO(bajtos) should we abort here and call cb(err)?

--- a/test/automigrate.test.js
+++ b/test/automigrate.test.js
@@ -18,11 +18,13 @@ describe('sql connector', function() {
     ds.connector._tables = {};
     ds.connector._models = {};
     ds.createModel('m1', {});
+    ds.createModel('m2', {});
   });
 
   it('automigrate all models', function(done) {
     ds.automigrate(function(err) {
       expect(ds.connector._tables).have.property('m1');
+      expect(ds.connector._tables).have.property('m2');
       done(err);
     });
   });
@@ -42,10 +44,17 @@ describe('sql connector', function() {
   });
 
   it('automigrate reports errors for models not attached', function(done) {
-    ds.automigrate(['m1', 'm2'], function(err) {
+    ds.automigrate(['m1', 'm3'], function(err) {
       expect(err).to.be.an.instanceOf(Error);
       expect(ds.connector._tables).to.not.have.property('m1');
-      expect(ds.connector._tables).to.not.have.property('m2');
+      expect(ds.connector._tables).to.not.have.property('m3');
+      done();
+    });
+  });
+
+  it('automigrate tables in series', function(done) {
+    ds.automigrate(['m1', 'm2'], function(err) {
+      expect(Object.keys(ds.connector._tables)).to.deep.equal(['m1', 'm2']);
       done();
     });
   });


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-connector/issues/168

Replaces `async.each` with `async.eachSeries` in `automigrate()` and `autoudate()` so migrations are run in a series instead of in parallel.  This enforces the model order so foreign key constructs with Postgres are possible. 

Previously it was impossible to enforce order in Loopback 4 using the `models` option to  `migrateSchema({models: ['m1', 'm2']})` as documented here https://loopback.io/doc/en/lb4/todo-list-tutorial-sqldb.html

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
