### PR TITLE
fix how connector gets column name for id property

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -421,17 +421,13 @@ SQLConnector.prototype.propertyName = function(model, column) {
 };
 
 /**
- * Get the id column name
+ * Get the id column name.
  * @param {String} model The model name
  * @returns {String} The id column name
  */
 SQLConnector.prototype.idColumn = function(model) {
-  let name = this.getDataSource(model).idColumnName(model);
-  const dbName = this.dbName;
-  if (typeof dbName === 'function') {
-    name = dbName(name);
-  }
-  return name;
+  const idName = this.getDataSource(model).getModelDefinition(model).idName();
+  return this.column(model, idName);
 };
 
 /**

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -17,6 +17,7 @@ const ds = new juggler.DataSource({
 /* eslint-disable one-var */
 let connector;
 let Customer;
+let Order;
 /* eslint-enable one-var */
 
 describe('sql connector', function() {
@@ -58,6 +59,24 @@ describe('sql connector', function() {
         address: String,
       },
       {testdb: {table: 'CUSTOMER'}});
+    Order = ds.createModel('order',
+      {
+        id: {
+          id: true,
+          type: Number,
+          testdb: {
+            column: 'orderId',
+            dataType: 'INTEGER',
+          },
+        }, des: {
+          type: String,
+          name: 'des',
+          testdb: {
+            column: 'description',
+          },
+        },
+      },
+      {testdb: {table: 'ORDER'}});
   });
 
   it('should map table name', function() {
@@ -78,6 +97,12 @@ describe('sql connector', function() {
   it('prefers database-specific column name over property name', function() {
     const column = connector.column('customer', 'lastName');
     expect(column).to.eql('LASTNAME');
+  });
+
+  it('uses database-specific column name over property name even if the column name \
+  does not follow the connector-specific configuration (UPPERCASE)', function() {
+    const column = connector.column('order', 'des');
+    expect(column).to.eql('description');
   });
 
   it('prefers property name when database is different', function() {
@@ -102,6 +127,13 @@ describe('sql connector', function() {
   it('should map id column name', function() {
     const idCol = connector.idColumn('customer');
     expect(idCol).to.eql('NAME');
+  });
+
+  it('should map id column name even if the column name does not \
+  follow the connector-specific configuration (UPPERCASE)', function() {
+    const idCol = connector.idColumn('order');
+    // shouldn't be converted to ORDERID
+    expect(idCol).to.eql('orderId');
   });
 
   it('should find escaped id column name', function() {


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

connects to https://github.com/strongloop/loopback-next/issues/4751

LB4 allows us to have different name for model properties and column names, it can done by:
```
export class TestTable extends Entity {
  @property({
    type: 'number',
    required: false,
    scale: 0,
    id: 1,
    postgresql: {
      columnName: 'testId', // ->set col name
      dataType: 'int',
    },
  })
  id: number;

  @property({
    type: 'string',
    required: true,
    length: 100,
    postgresql: {
      columnName: 'name',
      dataType: 'character varying',
      dataLength: 100,
    },
  })
  testName: string;
```
In `loopback-connector`, we have 2 different functions `idColumn` and `column` to get the defined column name, the previous one is for id properties.

 Idealy, `column` and `idColumn` return the column name that we defined in model definition (e.g `testId` in the above example). If it doesn't exist, it returns the id property name itself (e.g `id` in the example). And also Postgres has the `dbName` function. **If a property doesn't have a column name defined**, `dbName` would convert property names to lowercase as the default column name for that property as lowercase is the default naming convention of Postgres  (e.g 
```
  @property({
    type: 'string',
    required: true,
    id: true
  })
  willBeConvertedToLowercase: string; -> its column name in postgres is `willbeconvertedtolowercase`
```
However, `idColumn` function is problematic along with Postgres
Notice that function `idColumn`
```ts
SQLConnector.prototype.idColumn = function(model) {
  let name = this.getDataSource(model).idColumnName(model);

  const dbName = this.dbName;
// it doesn't check if the column name is defined
  if (typeof dbName === 'function') {
    name = dbName(name);
  }
  return name;
};
```
converts the id column name `name` to lowercase no matter the column name is defined or not. 
(e.g
case 1: `willBeConvertedToLowercase` -> `willbeconvertedtolowercase`
case 2: `testId` -> `testid`
)
case 1 is fine cause it doesn't have a defined column name, it creates table with column name `willbeconvertedtolowercase`, and it matches the result of `idColumn('..')`

case 2 is a bug. Because when the column name is defined in the model, it matches _the defined column name_ for CRUD operations (i.e the db column is `testId`). But the result of `idColumn('testTable')` is `testid`. That's why it failed to match and we see bugs such as https://github.com/strongloop/loopback-next/issues/4751 and https://github.com/strongloop/loopback-next/issues/3749.

## Proposal
Inspired by @bajtos , `SQLConnector.prototype.idColumn` is used to find the name of the id property, and let `SQLConnector.prototype.column` to decide the column name.

### Notice

Cloudant still has the invalid docker image so it would fail.

## Follow-up stories
https://github.com/strongloop/loopback-next/issues/4763

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
