### PR TITLE
Fix assertion timeout logging huge parameters

### DIFF
--- a/lib/parameterized-sql.js
+++ b/lib/parameterized-sql.js
@@ -5,6 +5,7 @@
 
 'use strict';
 const assert = require('assert');
+const util = require('util');
 const PLACEHOLDER = '?';
 
 module.exports = ParameterizedSQL;
@@ -35,11 +36,19 @@ function ParameterizedSQL(sql, params) {
   assert(Array.isArray(this.params), 'params must be an array');
 
   const parts = this.sql.split(PLACEHOLDER);
-  assert(parts.length - 1 === this.params.length,
-    'The number of ? (' + (parts.length - 1) +
-    ') in the sql (' + this.sql + ') must match the number of params (' +
-    this.params.length +
-    ') ' + this.params);
+  if (parts.length - 1 !== this.params.length) {
+    throw new assert.AssertionError({
+      message: util.format(
+        'The number of ? (%s) in the sql (%s) must match the number of params (%s) %o',
+        parts.length - 1,
+        this.sql,
+        this.params.length,
+        this.params,
+      ),
+      actual: this.params.length,
+      expected: parts.length - 1,
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
Fixed a problem that hangs code when, for example a param is a very large Buffer.

Fixes #161

