### PR TITLE
Drop support for Node.js 8.x, start testing 14.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ language: node_js
 node_js:
   - "10"
   - "12"
+  - "14"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "loopback-connector",
-  "version": "4.11.1",
+  "version": "5.0.0-dev",
   "description": "Building blocks for LoopBack connectors",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "author": "IBM Corp.",
   "keywords": [


### PR DESCRIPTION
- [SEMVER-MAJOR] Drop support for Node.js 8.x, it's no longer supported by Node.js project
- travis: add Node.js 14.x

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
