### PR TITLE
Group clauses for AND/OR conditions

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1049,7 +1049,7 @@ SQLConnector.prototype._buildWhere = function(model, where) {
           }
         }
         stmt.merge({
-          sql: branches.join(' ' + key.toUpperCase() + ' '),
+          sql: '(' + branches.join(' ' + key.toUpperCase() + ' ') + ')',
           params: branchParams,
         });
         whereStmts.push(stmt);

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -148,7 +148,7 @@ describe('sql connector', function() {
     const where = connector.buildWhere('customer',
       {or: [{name: 'John'}, {name: 'Mary'}]});
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE (`NAME`=?) OR (`NAME`=?)',
+      sql: 'WHERE ((`NAME`=?) OR (`NAME`=?))',
       params: ['John', 'Mary'],
     });
   });
@@ -157,7 +157,7 @@ describe('sql connector', function() {
     const where = connector.buildWhere('customer',
       {and: [{name: 'John'}, {vip: true}]});
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE (`NAME`=?) AND (`VIP`=?)',
+      sql: 'WHERE ((`NAME`=?) AND (`VIP`=?))',
       params: ['John', true],
     });
   });
@@ -238,7 +238,7 @@ describe('sql connector', function() {
     const where = connector.buildWhere('customer',
       {and: [{name: 'John'}, {or: [{vip: true}, {address: null}]}]});
     expect(where.toJSON()).to.eql({
-      sql: 'WHERE (`NAME`=?) AND ((`VIP`=?) OR (`ADDRESS` IS NULL))',
+      sql: 'WHERE ((`NAME`=?) AND (((`VIP`=?) OR (`ADDRESS` IS NULL))))',
       params: ['John', true],
     });
   });
@@ -341,6 +341,21 @@ describe('sql connector', function() {
   });
 
   it('builds SELECT', function() {
+    const sql = connector.buildSelect('customer', {
+      order: 'name',
+      limit: 5,
+      where: {or: [{name: 'Top Cat'}, {address: 'Trash can'}], vip: true},
+    });
+    expect(sql.toJSON()).to.eql({
+      sql:
+        'SELECT `NAME`,`middle_name`,`LASTNAME`,`VIP`,`primary_address`,' +
+        '`ADDRESS` FROM `CUSTOMER` WHERE ((`NAME`=$1) OR (`ADDRESS`=$2)) ' +
+        'AND `VIP`=$3 ORDER BY `NAME` LIMIT 5',
+      params: ['Top Cat', 'Trash can', true],
+    });
+  });
+
+  it('builds SELECT with where', function() {
     const sql = connector.buildSelect('customer',
       {order: 'name', limit: 5, where: {name: 'John'}});
     expect(sql.toJSON()).to.eql({


### PR DESCRIPTION
This is required to preserve the order of conditions:

```
where: {or: [{name: 'Top Cat'}, {address: 'Trash can'}], vip: true},
```

Before this PR:

```
WHERE (`NAME`=$1) OR (`ADDRESS`=$2) AND `VIP`=$3
```

With this PR:

```
WHERE ((`NAME`=$1) OR (`ADDRESS`=$2)) AND `VIP`=$3
```


**Need to watch downstream builds to make suer it won't break existing tests**



## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
